### PR TITLE
Fix call to LRG_Abacus_DM dict to fit new call to paths 

### DIFF
--- a/acm/hod/cutsky.py
+++ b/acm/hod/cutsky.py
@@ -64,7 +64,7 @@ class CutskyHOD:
         vel = np.c_[hod_dict['VX'], hod_dict['VY'], hod_dict['VZ']]
         return pos.astype(np.float32), vel.astype(np.float32)
 
-    def setup_hod_debug(self, DM_DICT: dict = LRG_Abacus_DM['box']):
+    def setup_hod_debug(self, DM_DICT: dict = LRG_Abacus_DM):
         """
         Convenience function only used to speed up debugging.
         """


### PR DESCRIPTION
I forgot to remove the call to box in one function (it is now handled by the `acm.utils.paths.reader.get_Abacus_dirs function`)