### PR TITLE
Remove harcoding of survey program, boxsize, boxpad

### DIFF
--- a/scripts/desi/cutsky/cutsky.py
+++ b/scripts/desi/cutsky/cutsky.py
@@ -109,7 +109,7 @@ abacus = CutskyHOD(varied_params=hod_params.keys(),
 # sample HOD parameters and build the cutsky mock
 hod = {key: hod_params[key][30] for key in hod_params.keys()}
 data, randoms = abacus.run(hod, nthreads=128, generate_randoms=True, alpha_randoms=5,
-                  region='NGC', release='Y1')
+                  region='NGC', release='Y1', program='dark')
 
 # get positions for clustering analysis
 data_positions = get_clustering_positions(data)


### PR DESCRIPTION
The survey program (e.g. dark, bright) is no longer hardcoded and can be specified with the `program` parameter in the `CutskyHOD.run` method.

The boxsize and boxpad values were previously hardcoded across multiple locations. They are now all set to shared class attributes, `CutskyHOD.boxsize_snapshot` and `CutskyHOD.boxpad`, which are not user inputs, but can be modified if needed for debugging purposes.