### PR TITLE
Cosmodesi box outputs

### DIFF
--- a/acm/hod/box.py
+++ b/acm/hod/box.py
@@ -452,6 +452,7 @@ class BoxHOD:
         np.ndarray
             Array of galaxy positions with shape (N_gal, 3).
         """
+        hod_dict = hod_dict.copy()  # Avoid modifying the original dictionary
         tracer_dict = hod_dict[tracer] if tracer is not None else hod_dict
         
         # Apply RSD before AP distortions
@@ -499,6 +500,7 @@ class BoxHOD:
         -------
         dict
             Dictionary containing the HOD catalog with redshift-space distortions to the specified axis.
+            Will overwrite the input `tracer_dict` in place, use a copy if needed !
         """
         ax = los.upper()
         offset = boxsize / 2 
@@ -533,6 +535,8 @@ class BoxHOD:
         -------
         dict
             Dictionary containing the HOD catalog with Alcock-Paczynski distortions applied to the specified axis.
+            Will overwrite the input `tracer_dict` in place, use a copy if needed !
+
         """
         for ax in ('X', 'Y', 'Z'):
             pos = tracer_dict[ax]


### PR DESCRIPTION
Sets the RSD and AP distorsions application outside of the `run()` method, to allow:
- storing only the information that allows the reconstruction of the different elements we want to compute
- on-the-fly computation of the positions and boxsizes depending on the los

> [!Warning]
> This will need to be taken into account when passing `BoxHOD` outputs to `CutskyHOD` !
> (We don't pass RSD or AP distorsions ATM, but if we do we'll need to be careful about this or need to implement similar methods to the `CustkyHOD` class)

> [!Important]
> Please, merge #57 before merging this one, it will cause merge issues but it will be simpler to solve them in this way than the other


> Solves #58 