### PR TITLE
bug fix for lightcone mocks

### DIFF
--- a/acm/hod/cutsky.py
+++ b/acm/hod/cutsky.py
@@ -404,8 +404,13 @@ class CutskyHOD(BaseCutskyCatalog):
             Number of threads to use for sampling, by default 1.
         seed : float, optional
             Random seed for reproducibility, by default 0.
-        target_nbar : float, optional
-            Number density to downsample the HOD catalog to, in (Mpc/h)^-3.
+        target_nbar : list[float], optional
+            List containing (min_nbar, max_nbar) for downsampling catalogue 
+            to desired density (nbar > max_nbar) or cutting from sample 
+            (nbar < min_nbar). If only one value provided, this is taken as 
+            the maximum threshold (no minimum threshold applied). Default 
+            is None (no thresholds applied).
+        
 
         Returns
         -------
@@ -416,7 +421,7 @@ class CutskyHOD(BaseCutskyCatalog):
             hod_params,
             seed=seed,
             nthreads=nthreads,
-            tracer_density_mean=target_nbar
+            tracer_density=target_nbar
         )[self.tracer]
         pos = np.c_[hod_dict['X'], hod_dict['Y'], hod_dict['Z']]
         vel = np.c_[hod_dict['VX'], hod_dict['VY'], hod_dict['VZ']]

--- a/acm/hod/lightcone.py
+++ b/acm/hod/lightcone.py
@@ -115,7 +115,7 @@ class BaseLightconeCatalog(ABC):
         select_mask = np.random.uniform(size=len(self.catalog['Z'])) < ratio_spline(self.catalog['Z'])
         for key in self.catalog.keys():
             self.catalog[key] = self.catalog[key][select_mask]
-
+        self.catalog['NZ'] = data_nz[select_mask]
         self.logger.info(f'Downsampled data nbar: {self.get_data_nbar(self.catalog, full_sky)}' )
     
     def get_data_nbar(self, data, full_sky: bool = False):


### PR DESCRIPTION
Added missing NZ column to lightcone mocks (to match cutsky mocks format) and modified the BaseLightconeCatalog class to be up to date with changes to the BoxHOD class. 