### PR TITLE
Skip class instantiation on file compression script

### DIFF
--- a/scripts/emc/measurements/compress_files.py
+++ b/scripts/emc/measurements/compress_files.py
@@ -21,5 +21,5 @@ paths = {
     'param_dir': None
 }
 
-observable = getattr(emc, statistic)(paths=paths)
-observable.compress_data(save_to=paths['data_dir'], add_covariance=add_covariance, n_hod=n_hod)
+observable = getattr(emc, statistic)
+observable.compress_data(paths=paths, save_to=paths['data_dir'], add_covariance=add_covariance, n_hod=n_hod)


### PR DESCRIPTION
Small modification to EMC file compression script to skip observable class instantiation per last updates.