### PR TITLE
Enable MPI parallelization for cutsky class

### DIFF
--- a/acm/estimators/galaxy_clustering/backends/jaxpower.py
+++ b/acm/estimators/galaxy_clustering/backends/jaxpower.py
@@ -76,14 +76,8 @@ class JaxpowerBackend:
         """
         self.logger = logging.getLogger('JaxpowerBackend')
         self.name = 'jaxpower'
-        # Set mesh attributes directly if passed, otherwise infer from positions
-        if set(kwargs.keys()).issubset(set(MeshAttrs.__dataclass_fields__.keys())): 
-            self.mattrs = MeshAttrs(**kwargs) 
-        else:
-            if jax.process_index() == 0:
-                self.logger.info('Inferring mesh attributes from data and randoms positions.')  
-            pos = [p for p in [data_positions, randoms_positions] if p is not None] # get_mesh_attrs raises an error if randoms_positions is None
-            self.mattrs = get_mesh_attrs(*pos, **kwargs)
+        pos = [p for p in [data_positions, randoms_positions] if p is not None]
+        self.mattrs = get_mesh_attrs(*pos, **kwargs)
             
         self.data_mesh = ParticleField(data_positions, data_weights, attrs=self.mattrs, exchange=True, backend='jax')
         self.randoms_mesh = None
@@ -175,6 +169,8 @@ class JaxpowerBackend:
             self.delta_mesh = data_mesh - alpha * randoms_mesh
             if threshold_randoms is not None:
                 self.delta_mesh = self.delta_mesh.clone(value=jnp.where(randoms_mesh.value > threshold_randoms, self.delta_mesh.value / (alpha * randoms_mesh.value), 0.))
+            else:
+                self.delta_mesh = self.delta_mesh / (alpha * randoms_mesh)
         else:
             self.mean = data_mesh.mean()
             self.delta_mesh = data_mesh / self.mean - 1

--- a/acm/estimators/galaxy_clustering/spectrum.py
+++ b/acm/estimators/galaxy_clustering/spectrum.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 import jax
-from jaxpower import MeshAttrs, ParticleField, FKPField, BinMesh2SpectrumPoles, get_mesh_attrs, compute_mesh2_spectrum, compute_fkp2_shotnoise, compute_box2_normalization
+from jaxpower import FKPField, BinMesh2SpectrumPoles, get_mesh_attrs, compute_mesh2_spectrum, compute_fkp2_shotnoise, compute_fkp2_normalization, compute_box2_normalization
 
 from .base import BaseEstimator
 
@@ -25,15 +25,58 @@ class PowerSpectrumMultipoles(BaseEstimator):
             donate_argnums=[0]
         )
 
-    def compute_spectrum(self, edges: dict = {'step': 0.001}, ells: tuple = (0, 2, 4), los: str = 'z', save_fn: Optional[str] = None):
+    def compute_spectrum(self, edges: dict = {'step': 0.001}, ells: tuple = (0, 2, 4), los: str = 'z',
+            interlacing: int = 3, compensate: bool = True, resampler='tsc', save_fn: Optional[str] = None):
+        """
+        Calculate the power spectrum multipoles.
+        
+        If randoms are provided (self.has_randoms=True), uses FKP estimator with 'firstpoint' line-of-sight.
+        Otherwise, uses box normalization with specified line-of-sight.
+        
+        Parameters
+        ----------
+        edges : dict, optional
+            Binning specification for the spectrum. Default is {'step': 0.001}.
+        ells : tuple, optional
+            Multipole orders to compute. Default is (0, 2, 4).
+        los : str, optional
+            Line-of-sight direction. Default is 'z'. Used only when has_randoms=False.
+            When has_randoms=True, 'firstpoint' is always used.
+        interlacing : int, optional
+            Interlacing factor to reduce aliasing. Default is 3.
+        compensate : bool, optional
+            Whether to compensate for the mass assignment scheme. Default is True.
+        resampler : str, optional
+            Resampling scheme to use for mesh painting. Default is 'tsc'.
+        save_fn : str, optional
+            Path to save the computed spectrum. Saves only on process 0.
+            
+        Returns
+        -------
+        spectrum
+            Computed power spectrum multipoles.
+        """
         self.bin = BinMesh2SpectrumPoles(
             self.mattrs,
             edges=edges,
             ells=ells,
         )
-        norm = compute_box2_normalization(self.data_mesh, bin=self.bin)
-        num_shotnoise = compute_fkp2_shotnoise(self.data_mesh, bin=self.bin)
-        spectrum = self.jitted_compute_mesh2_spectrum(self.delta_mesh * self.mean, bin=self.bin, los=los)
+        
+        if self.has_randoms:
+            self.logger.info("Computing power spectrum using FKP estimator with randoms.")
+            fkp = FKPField(self.data_mesh, self.randoms_mesh)
+            norm = compute_fkp2_normalization(fkp, bin=self.bin)
+            num_shotnoise = compute_fkp2_shotnoise(fkp, bin=self.bin)
+            delta_mesh = fkp.paint(resampler=resampler, interlacing=interlacing, compensate=compensate, out='real')
+            spectrum = self.jitted_compute_mesh2_spectrum(delta_mesh, bin=self.bin, los='firstpoint')
+        else:
+            self.logger.info("Computing power spectrum using box normalization without randoms.")
+            norm = compute_box2_normalization(self.data_mesh, bin=self.bin)
+            num_shotnoise = compute_fkp2_shotnoise(self.data_mesh, bin=self.bin)
+            delta_mesh = self.data_mesh.paint(resampler=resampler, interlacing=interlacing, compensate=compensate, out='real')
+            delta_mesh -= delta_mesh.mean()
+            spectrum = self.jitted_compute_mesh2_spectrum(delta_mesh, bin=self.bin, los=los)
+        
         self.spectrum = spectrum.clone(norm=norm, num_shotnoise=num_shotnoise)
 
         if save_fn and jax.process_index() == 0:

--- a/acm/hod/cutsky.py
+++ b/acm/hod/cutsky.py
@@ -47,8 +47,10 @@ class BaseCutskyCatalog(ABC):
     compute number density, and check if coordinates are within a specified photometric region.
     It is intended to be subclassed for specific cutsky catalog implementations.
     """
-    def __init__(self):
-        pass
+    @CurrentMPIComm.enable
+    def __init__(self, mpicomm=None, mpiroot=0):
+        self.mpicomm = mpicomm
+        self.mpiroot = mpiroot
 
     def apply_angular_mask(
         self,
@@ -416,7 +418,6 @@ class BaseCutskyCatalog(ABC):
             logger.info(f'Plot save in fiberasignment_{npasses}npasses.png')
         mpicomm.Barrier()
 
-    
     def save(self, filename: str) -> None:
         """
         Save the cutsky catalog to a file. Supports .fits and .npy formats.
@@ -463,7 +464,7 @@ class CutskyHOD(BaseCutskyCatalog):
         sim_type: str = 'base',
         tracer: str = 'LRG',
         DM_DICT: dict = None,
-        mpicomm = None,
+        **kwargs,
     ):
         """
         Initialize the CutskyHOD class. This checks the HOD parameters and 
@@ -500,16 +501,11 @@ class CutskyHOD(BaseCutskyCatalog):
             Dictionary containing the DM fields for the HOD sampling.
             If None, defaults to a value read from `acm.utils.paths` on NERSC systems.
             Defaults to None.
-        mpicomm : MPI communicator, optional
-            The MPI communicator for parallel processing. If None, defaults to
-            the current MPI communicator from mockfactory.
+        **kwargs: dict
+            Additional keyword arguments passed to the BaseCutskyCatalog class.
         """
-        super().__init__()
+        super().__init__(**kwargs)
         self.logger = logging.getLogger('CutskyHOD')
-        # if mpicomm is None:
-        #     mpicomm = MPI.COMM_WORLD
-        self.mpicomm = mpicomm
-        self.mpiroot = 0  # Root rank for MPI operations
         self.logger.info(f'Initializing CutskyHOD class on {self.mpicomm.size} MPI ranks.')
         self.config_file = config_file
         self.load_existing_hod = load_existing_hod
@@ -1075,10 +1071,12 @@ class CutskyHOD(BaseCutskyCatalog):
 
         return combined_raw_nbar
         
+
 class CutskyRandoms(BaseCutskyCatalog):
     """
     Class to generate randoms in a cutsky region.
     """
+    @CurrentMPIComm.enable
     def __init__(
         self,
         rarange: tuple = (0., 360.),
@@ -1088,7 +1086,7 @@ class CutskyRandoms(BaseCutskyCatalog):
         nbar: float | None = None,
         seed: int | None = None,
         cosmo_idx: int = 0,
-        mpicomm = None
+        **kwargs,
     ):
         """
         Initialize the CutskyRandoms class. This generates randoms in a cutsky region
@@ -1111,16 +1109,11 @@ class CutskyRandoms(BaseCutskyCatalog):
             Random seed for reproducibility, by default None.
         cosmo_idx : int, optional
             Index of the AbacusSummit cosmology. Used for the redshift-distance relation.
-        mpicomm : MPI communicator, optional
-            The MPI communicator for parallel processing. If None, defaults to
-            the current MPI communicator from mockfactory.
+        **kwargs: dict
+            Additional keyword arguments passed to the BaseCutskyCatalog class.
         """
-        super().__init__()
+        super().__init__(**kwargs)
         self.logger = logging.getLogger('CutskyRandoms')
-        if mpicomm is None:
-            from mockfactory.utils import CurrentMPIComm
-            mpicomm = CurrentMPIComm.get()
-        self.mpicomm = mpicomm
         self.rarange = rarange
         self.decrange = decrange
         self.zrange = zrange


### PR DESCRIPTION
Leveraging the MPI capabilities of mockfactory, we can gain several factors of speed improvement for cutsky mock generation:

```
[000000.24]  01-30 12:28  CutskyHOD                    INFO     Initializing CutskyHOD class on 1 MPI ranks.
[000100.63]  01-30 12:29  CutskyHOD                    INFO     Processing snapshot at z = 0.8 for redshift range (0.8, 1.1)
[000144.04]  01-30 12:30  CutskyHOD                    INFO     Applied RSD at z=0.8 in 12.33 seconds.
```

v/s

```
[000000.43]  01-30 12:46  CutskyHOD                    INFO     Initializing CutskyHOD class on 32 MPI ranks.
[000011.54]  01-30 12:46  CutskyHOD                    INFO     Processing snapshot at z = 0.8 for redshift range (0.8, 1.1)
[000016.14]  01-30 12:46  CutskyHOD                    INFO     Applied RSD at z=0.8 in 0.58 seconds.
```

The HOD sampling part (abacushod) is not MPI parallelized, so that is processed by the master rank, and then scattered to other processes.