### PR TITLE
bug fix for cutsky n(z) and lightcone __init__

### DIFF
--- a/acm/hod/cutsky.py
+++ b/acm/hod/cutsky.py
@@ -743,7 +743,7 @@ class CutskyHOD(BaseCutskyCatalog):
                 )
             # Each rank has a portion of box_positions after scatter
             # Need to gather total count for raw_nbar calculation
-            total_particles = mpy.csize(box_positions, mpicomm=self.mpicomm)
+            total_particles = mpy.csize(box_positions, mpicomm=self.mpicomm) // 3
             self.raw_nbar_snapshots.append( total_particles / (self.boxsize**3) )
 
             # replicate the box along each axis to cover more volume

--- a/acm/hod/lightcone.py
+++ b/acm/hod/lightcone.py
@@ -3,6 +3,8 @@ import os
 import yaml
 import numpy as np
 from pathlib import Path
+from mpytools import CurrentMPIComm
+
 
 # cosmodesi/acm
 import mockfactory
@@ -23,8 +25,10 @@ class BaseLightconeCatalog(ABC):
     Base class for mock lightcone catalogs.
     """
 
-    def __init__(self):
-        pass
+    @CurrentMPIComm.enable
+    def __init__(self, mpicomm=None, mpiroot=0):
+        self.mpicomm = mpicomm
+        self.mpiroot = mpiroot
 
     """
     def apply_angular_mask(self):
@@ -364,7 +368,7 @@ class LightconeHOD(CutskyHOD, BaseLightconeCatalog):
                                               position='Position', velocity='Velocity',
                                               boxsize=boxsize, boxcenter=[boxsize/2, boxsize/2, boxsize/2])
             lightcone_shell = self.box_to_cutsky(box=box, zmin=self.zrange[0], zmax=self.zrange[1], 
-                                          zrsd=zsnap, apply_rsd=True)
+                                          zrsd=zsnap, apply_rsd=True) 
             for key in self.keys_lightcone:
                 self.catalog[key].extend(lightcone_shell[key])
             del box_positions, box_velocities, box, lightcone_shell


### PR DESCRIPTION
This branch resolves a [missing factor of 3](https://github.com/epaillas/acm/blob/669a38cf5953e6df4422059f72f3210683de3563/acm/hod/cutsky.py#L746) in the calculation of the cutsky raw target density (due to the shape of `box_positions` being `(N, 3)`) and updates the lightcone __init__ function to [set up mpi](https://github.com/epaillas/acm/blob/669a38cf5953e6df4422059f72f3210683de3563/acm/hod/lightcone.py#L29) and thus stop the class from raising an error when it attempts to access inherited CutskyHOD methods.