### PR TITLE
Cosmodesi BoxHOD.run split

### DIFF
--- a/acm/hod/box.py
+++ b/acm/hod/box.py
@@ -343,7 +343,7 @@ class BoxHOD:
         )
 
         # ensure number density matches expectation of HMF
-        n_gal_diff = n_gal_mock / min(n_target.max(), self.n_gal) - 1
+        n_gal_diff = n_gal_mock / min(n_target, self.n_gal) - 1
         if abs(n_gal_diff) > rtol:
             self.logger.warning(f'Number density of mock does not match expectation ({n_gal_diff*100:.0f}% offset). Adjust the halo catalogue subsampling!')
 


### PR DESCRIPTION
I've split elements from BoxHOD.run in different methods to be able to call them outside the mock computation.

If I've done this correctly, we should be able to get the theoritical n_gal with:
```python
box = BoxHOD(
    varied_params = hod_params,
    cosmo_idx = cosmo_idx,
    phase_idx = phase_idx,
    sim_type = sim_type,
    redshift = redshift,
)

hod_params = box.param_mapping(hod_params)
ball = box.setup_ball_tracer(box.ball, hod_params, tracer='LRG')

n_gal, f_sat = box.ngal_fsat_from_ball(ball, tracer, box.boxsize, add_ap=True, q_par=box.q_par, q_perp=box.q_perp)
```

@ntbfin00 could you check that this implementation still works as expected and that you recover the correct n_gal value ? (I can't test this as I've not done this change on NERSC because I have jobs running on another branch :/ )

> [!NOTE]
> I'm also working on a rework of the whole BoxHOD class to test an implementation solving #178 , on a child branch of this one.