### PR TITLE
only check catalog when target_density is provided

### DIFF
--- a/acm/hod/box.py
+++ b/acm/hod/box.py
@@ -199,7 +199,7 @@ class BoxHOD:
 
     def check_catalog(self, hod_dict: dict, n_target: float, rtol: float = 0.01) -> None:
         """
-        Check if check_catalog number density and satellite fractions match expectations, i.e. halo/particle catalogue subsampling is sufficient for given parameter values.
+        Check if catalogue number density and satellite fractions match expectations, i.e. halo/particle catalogue subsampling is sufficient for given parameter values.
 
         Parameters
         ----------


### PR DESCRIPTION
Bugfix for uneeded usage of `n_target` when it has not been created (meaning when user has not provided `tracer_density`, as in the case of the lightcone mocks). Also removes the `subsamples` variable from box.py to be consistent with previous changes made to the script