### PR TITLE
Adding missing PDF observable file

### DIFF
--- a/acm/observables/emc/pdf.py
+++ b/acm/observables/emc/pdf.py
@@ -1,0 +1,19 @@
+import xarray
+import numpy as np
+import glob
+from pathlib import Path
+from .base import BaseObservableEMC
+import matplotlib.pyplot as plt
+from jaxpower import read
+from acm.utils.default import cosmo_list # List of cosmologies in AbacusSummit
+from acm.utils.plotting import set_plot_style
+from acm.utils.decorators import temporary_class_state
+from acm.utils.xarray import dataset_to_dict, split_vars
+
+
+class GalaxyOverdensityPDF(BaseObservableEMC):
+    """
+    Class for the Emulator's Mock Challenge galaxy overdensity PDF.
+    """
+    def __init__(self, **kwargs):
+        super().__init__(stat_name='pdf', **kwargs)


### PR DESCRIPTION
This pull request introduces a new observable class for handling galaxy overdensity PDF data in the Emulator's Mock Challenge. The main addition is the `GalaxyOverdensityPDF` class, which extends the `BaseObservableEMC` and sets up the structure for further development of PDF-related functionality.

New observable class:

* Added the `GalaxyOverdensityPDF` class to `acm/observables/emc/pdf.py`, inheriting from `BaseObservableEMC` and initializing with `stat_name='pdf'`.
* Included necessary imports for data handling, plotting, and utility functions to support the new class.