### PR TITLE
Rewrite fourier saved files

### DIFF
--- a/acm/estimators/galaxy_clustering/density_split.py
+++ b/acm/estimators/galaxy_clustering/density_split.py
@@ -125,7 +125,7 @@ class DensitySplit(BaseEstimator):
                 "Supported extensions are: .hdf5, .h5, .npy"
             )
 
-    def save_powers(self, powers, filename, attrs=None):
+    def save_powers(self, powers: list, filename: str, attrs = None) -> None:
         """
         Save a list of per-quantile power-spectrum objects to an lsstypes ObservableTree.
 
@@ -136,9 +136,12 @@ class DensitySplit(BaseEstimator):
         filename : str or path-like
             Output filename where the ObservableTree will be written.
         """
+        if jax.process_index() != 0: # Only process 0 saves to disk
+            return # Exit early for non-zero processes
+        
         path = Path(filename)
         self.logger.info(f'Saving to {filename}')
-
+        
         if path.suffix in ['.hdf5', '.h5']:
             leaves = []
             for quantile in range(self.nquantiles):

--- a/acm/estimators/galaxy_clustering/density_split.py
+++ b/acm/estimators/galaxy_clustering/density_split.py
@@ -115,7 +115,9 @@ class DensitySplit(BaseEstimator):
                 corr = from_pycorr(correlations[quantile])
                 leaves.append(corr)
             tree = ObservableTree(leaves, quantiles=list(range(self.nquantiles)), attrs=attrs)
-            tree.write(path)
+            tmp_filename = path.with_name(path.stem + '.tmp' + path.suffix)
+            tree.write(tmp_filename)
+            tmp_filename.replace(path) # Atomic move to avoid partial writes
         elif path.suffix == '.npy':
             np.save(filename, correlations)
         else:             raise ValueError(
@@ -142,7 +144,9 @@ class DensitySplit(BaseEstimator):
             for quantile in range(self.nquantiles):
                 leaves.append(powers[quantile])  # assumes power is calculated with jax-power
             tree = ObservableTree(leaves, quantiles=list(range(self.nquantiles)), attrs=attrs)
-            tree.write(filename)
+            tmp_filename = path.with_name(path.stem + '.tmp' + path.suffix)
+            tree.write(tmp_filename)
+            tmp_filename.replace(path) # Atomic move to avoid partial writes
         elif path.suffix == '.npy':
             np.save(filename, powers)
         else:

--- a/acm/estimators/galaxy_clustering/density_split.py
+++ b/acm/estimators/galaxy_clustering/density_split.py
@@ -106,6 +106,9 @@ class DensitySplit(BaseEstimator):
         filename : str or path-like
             Output filename where the ObservableTree will be written.
         """
+        if jax.process_index() != 0: # Only process 0 saves to disk
+            return # Exit early for non-zero processes
+        
         path = Path(filename)
         self.logger.info(f'Saving to {filename}')
 

--- a/acm/estimators/galaxy_clustering/spectrum.py
+++ b/acm/estimators/galaxy_clustering/spectrum.py
@@ -1,6 +1,7 @@
+import time
+from pathlib import Path
 from typing import Optional
 
-import time
 import jax
 from jaxpower import FKPField, BinMesh2SpectrumPoles, get_mesh_attrs, compute_mesh2_spectrum, compute_fkp2_shotnoise, compute_fkp2_normalization, compute_box2_normalization
 
@@ -81,9 +82,9 @@ class PowerSpectrumMultipoles(BaseEstimator):
         
         self.spectrum = spectrum.clone(norm=norm, num_shotnoise=num_shotnoise)
 
-        if save_fn and jax.process_index() == 0:
-            self.logger.info(f'Saving power spectrum to {save_fn}')
-            self.spectrum.write(save_fn)
+        if save_fn:
+            self.save(save_fn)
+        
         self.logger.info(f'Power spectrum computed in {time.time() - t0:.2f} s.')
         return self.spectrum
     
@@ -93,3 +94,18 @@ class PowerSpectrumMultipoles(BaseEstimator):
         k = poles[0].coords('k')
         poles = [pole.value() for pole in poles]
         return k, poles
+    
+    def save(self, fn: str):
+        """Save the computed power spectrum to a file. Only process 0 will write to disk.
+
+        Parameters
+        ----------
+        fn : str
+            Path to save the power spectrum. Only process 0 will write to disk.
+        """
+        fn = Path(fn) # Ensure fn is a Path object
+        tmp_fn = fn.with_name(fn.stem + '.tmp' + fn.suffix)
+        if jax.process_index() == 0:
+            self.spectrum.write(tmp_fn)
+            self.logger.info(f'Saving power spectrum to {fn}')
+            tmp_fn.replace(fn) # Atomic move to avoid partial writes

--- a/acm/estimators/galaxy_clustering/spectrum.py
+++ b/acm/estimators/galaxy_clustering/spectrum.py
@@ -27,8 +27,16 @@ class PowerSpectrumMultipoles(BaseEstimator):
             donate_argnums=[0]
         )
 
-    def compute_spectrum(self, edges: dict = {'step': 0.001}, ells: tuple = (0, 2, 4), los: str = 'z',
-            interlacing: int = 3, compensate: bool = True, resampler='tsc', save_fn: Optional[str] = None):
+    def compute_spectrum(
+        self, 
+        edges: dict = {'step': 0.001}, 
+        ells: tuple = (0, 2, 4), 
+        los: str = 'z',
+        interlacing: int = 3, 
+        compensate: bool = True, 
+        resampler='tsc', 
+        save_fn: Optional[str] = None
+    ):
         """
         Calculate the power spectrum multipoles.
         
@@ -82,27 +90,35 @@ class PowerSpectrumMultipoles(BaseEstimator):
         
         self.spectrum = spectrum.clone(norm=norm, num_shotnoise=num_shotnoise)
 
-        if save_fn and jax.process_index() == 0:
+        if save_fn:
             self.save(save_fn)
         
         self.logger.info(f'Power spectrum computed in {time.time() - t0:.2f} s.')
         return self.spectrum
     
-    def get_multipoles(self, kmin: Optional[float] = None, kmax: Optional[float] = None, rebin: int = 1):
+    def get_multipoles(
+        self, 
+        kmin: Optional[float] = None, 
+        kmax: Optional[float] = None, 
+        rebin: int = 1,
+    ):
         spectrum = self.spectrum.select(k=slice(0, None, rebin))
         poles = [spectrum.get(ell) for ell in spectrum.ells]
         k = poles[0].coords('k')
         poles = [pole.value() for pole in poles]
         return k, poles
     
-    def save(self, fn: str):
+    def save(self, fn: str) -> None:
         """Save the computed power spectrum to a file. Only process 0 will write to disk.
 
         Parameters
         ----------
         fn : str
-            Path to save the power spectrum. Only process 0 will write to disk.
+            Path to save the power spectrum.
         """
+        if jax.process_index() != 0: # Only process 0 saves to disk
+            return # Exit early for non-zero processes
+        
         fn = Path(fn) # Ensure fn is a Path object
         tmp_fn = fn.with_name(fn.stem + '.tmp' + fn.suffix)
         self.spectrum.write(tmp_fn)

--- a/acm/estimators/galaxy_clustering/spectrum.py
+++ b/acm/estimators/galaxy_clustering/spectrum.py
@@ -101,12 +101,33 @@ class PowerSpectrumMultipoles(BaseEstimator):
         kmin: Optional[float] = None, 
         kmax: Optional[float] = None, 
         rebin: int = 1,
+        return_k: bool = False,
     ):
+        """
+        Get the power spectrum multipoles, optionally rebinned and with k-range selection.
+        
+        Parameters
+        ----------
+        kmin : float, optional
+            Minimum k value to include. Default is None (no minimum).
+        kmax : float, optional
+            Maximum k value to include. Default is None (no maximum).
+        rebin : int, optional
+            Factor by which to rebin the k-bins. Default is 1 (no rebinning).
+        return_k : bool, optional
+            Whether to return the k values along with the multipoles. Default is False.
+        """
         spectrum = self.spectrum.select(k=slice(0, None, rebin))
+        if kmin is not None and kmax is not None:
+            spectrum = spectrum.select(k=(kmin, kmax))
+            
         poles = [spectrum.get(ell) for ell in spectrum.ells]
         k = poles[0].coords('k')
         poles = [pole.value() for pole in poles]
-        return k, poles
+        
+        if return_k:
+            return k, poles
+        return poles
     
     def save(self, fn: str) -> None:
         """Save the computed power spectrum to a file. Only process 0 will write to disk.

--- a/acm/estimators/galaxy_clustering/spectrum.py
+++ b/acm/estimators/galaxy_clustering/spectrum.py
@@ -82,7 +82,7 @@ class PowerSpectrumMultipoles(BaseEstimator):
         
         self.spectrum = spectrum.clone(norm=norm, num_shotnoise=num_shotnoise)
 
-        if save_fn:
+        if save_fn and jax.process_index() == 0:
             self.save(save_fn)
         
         self.logger.info(f'Power spectrum computed in {time.time() - t0:.2f} s.')
@@ -105,7 +105,6 @@ class PowerSpectrumMultipoles(BaseEstimator):
         """
         fn = Path(fn) # Ensure fn is a Path object
         tmp_fn = fn.with_name(fn.stem + '.tmp' + fn.suffix)
-        if jax.process_index() == 0:
-            self.spectrum.write(tmp_fn)
-            self.logger.info(f'Saving power spectrum to {fn}')
-            tmp_fn.replace(fn) # Atomic move to avoid partial writes
+        self.spectrum.write(tmp_fn)
+        self.logger.info(f'Saving power spectrum to {fn}')
+        tmp_fn.replace(fn) # Atomic move to avoid partial writes


### PR DESCRIPTION
Since the write method of the lsstypes save tends to sometime cause corrupted files (0.01%), I try to mitigate that by writing to a temporary file and moving the final result as an atomic move. (by Arnaud's recommendation)

Not sure if that will solve the issue, but it's worth a try 🤷🏼 