### PR TITLE
Toggle RSD for cutsky/lightcone mocks

### DIFF
--- a/acm/hod/cutsky.py
+++ b/acm/hod/cutsky.py
@@ -764,6 +764,7 @@ class CutskyHOD(BaseCutskyCatalog):
         release: str = 'Y1',
         target_nz_filename: str | None = None,
         custom_xyz_file: str | None = None,
+        apply_rsd: bool = True,
         nfw_draw_path: str = '/global/cfs/projectdirs/desi/users/arocher/nfw.npy'
     ) -> dict:
         """
@@ -792,6 +793,8 @@ class CutskyHOD(BaseCutskyCatalog):
         custom_xyz_file : str
             If not None, a custom file is read for the positions of the tracers that define
             the survey volume bounds
+        apply_rsd : bool
+            If True, redshift space distortions are applied to the mock. If False, RSD is not applied.
         nfw_draw_path: str, optional
             Samples from an NFW profile used for ELG cutsky mocks. Defaults to a location containing NFW
             samples on NERSC
@@ -859,7 +862,7 @@ class CutskyHOD(BaseCutskyCatalog):
                 zmin=zranges[0],
                 zmax=zranges[1],
                 zrsd=zsnap,
-                apply_rsd=True
+                apply_rsd=apply_rsd
             )
 
             for key in self.keys_cutsky:

--- a/acm/hod/cutsky.py
+++ b/acm/hod/cutsky.py
@@ -804,6 +804,15 @@ class CutskyHOD(BaseCutskyCatalog):
         dict
             The cutsky catalog containing positions, velocities, and other properties of the galaxies.
         """
+        
+        if apply_rsd and 'RSDPosition' not in self.keys_cutsky:
+            
+            self.keys_cutsky.append('RSDPosition')
+            
+        elif 'RSDPosition' in self.keys_cutsky:
+            
+            self.keys_cutsky.remove('RSDPosition') 
+
         self.catalog = self.init_cutsky()
         
         # construct one redshift shell at a time from the snapshots

--- a/acm/hod/cutsky.py
+++ b/acm/hod/cutsky.py
@@ -804,14 +804,10 @@ class CutskyHOD(BaseCutskyCatalog):
         dict
             The cutsky catalog containing positions, velocities, and other properties of the galaxies.
         """
-        
         if apply_rsd and 'RSDPosition' not in self.keys_cutsky:
-            
             self.keys_cutsky.append('RSDPosition')
-            
         elif 'RSDPosition' in self.keys_cutsky:
-            
-            self.keys_cutsky.remove('RSDPosition') 
+            self.keys_cutsky.remove('RSDPosition')
 
         self.catalog = self.init_cutsky()
         
@@ -1213,4 +1209,3 @@ class CutskyRandoms(BaseCutskyCatalog):
         d2r = mockfactory.DistanceToRedshift(distance=self.cosmo.comoving_radial_distance)
         self.catalog['Z'] = d2r(self.catalog['Distance'])
         self.catalog = {key: self.catalog[key] for key in self.keys_cutsky}
-

--- a/acm/hod/lightcone.py
+++ b/acm/hod/lightcone.py
@@ -330,7 +330,9 @@ class LightconeHOD(CutskyHOD, BaseLightconeCatalog):
             self, hod_params: dict, nthreads: int = 1, seed: float = 0, 
             existing_hod_path: str = None, 
             target_nz_filename: str = None,
-            full_sky: bool = None):
+            full_sky: bool = False,
+            apply_rsd: bool = True,
+            ):
         """
         Sample HOD galaxies from the snapshots and build a cutsky catalog.
         This does not yet apply the angular or radial masks, which should be done
@@ -354,6 +356,8 @@ class LightconeHOD(CutskyHOD, BaseLightconeCatalog):
             number density that the HOD boxes require to allow for a radial mask to be applied later.
         full_sky: bool
             If True, the survey volunme is scaled to the full sky rather than an octant
+        apply_rsd : bool
+            If True, redshift space distortions are applied to the mock. If False, RSD is not applied.
         Returns
         -------
         dict
@@ -388,7 +392,7 @@ class LightconeHOD(CutskyHOD, BaseLightconeCatalog):
                                               position='Position', velocity='Velocity',
                                               boxsize=boxsize, boxcenter=[boxsize/2, boxsize/2, boxsize/2])
             lightcone_shell = self.box_to_cutsky(box=box, zmin=self.zrange[0], zmax=self.zrange[1], 
-                                          zrsd=zsnap, apply_rsd=True) 
+                                          zrsd=zsnap, apply_rsd=apply_rsd) 
             for key in self.keys_lightcone:
                 self.catalog[key].extend(lightcone_shell[key])
             del box_positions, box_velocities, box, lightcone_shell

--- a/acm/hod/lightcone.py
+++ b/acm/hod/lightcone.py
@@ -363,6 +363,15 @@ class LightconeHOD(CutskyHOD, BaseLightconeCatalog):
         dict
             The cutsky catalog containing positions, velocities, and other properties of the galaxies.
         """  
+        
+        if apply_rsd and 'RSDPosition' not in self.keys_lightcone:
+            
+            self.keys_lightcone.append('RSDPosition')
+            
+        elif 'RSDPosition' in self.keys_lightcone:
+            
+            self.keys_lightcone.remove('RSDPosition') 
+            
         self.catalog = self.init_lightcone()
 
         boxsize = 2*self.boxsize if self.sim_type == 'base' else self.boxsize

--- a/acm/hod/lightcone.py
+++ b/acm/hod/lightcone.py
@@ -363,15 +363,11 @@ class LightconeHOD(CutskyHOD, BaseLightconeCatalog):
         dict
             The cutsky catalog containing positions, velocities, and other properties of the galaxies.
         """  
-        
         if apply_rsd and 'RSDPosition' not in self.keys_lightcone:
-            
             self.keys_lightcone.append('RSDPosition')
-            
         elif 'RSDPosition' in self.keys_lightcone:
-            
-            self.keys_lightcone.remove('RSDPosition') 
-            
+            self.keys_lightcone.remove('RSDPosition')
+
         self.catalog = self.init_lightcone()
 
         boxsize = 2*self.boxsize if self.sim_type == 'base' else self.boxsize


### PR DESCRIPTION
Removes hardcoded RSD application to cutsky/lightcone mocks and allows user to configure the desired behavior