### PR TITLE
Update WST EMC measurements and test mock number to v1.3

### DIFF
--- a/acm/observables/emc/wst_module.py
+++ b/acm/observables/emc/wst_module.py
@@ -16,7 +16,7 @@ class WaveletScatteringTransform(BaseObservableEMC):
     Class for the Emulator's Mock Challenge galaxy correlation
     function multipoles.
     """
-    def __init__(self, stat_name='wst', n_test=6*125, **kwargs):
+    def __init__(self, stat_name='wst', n_test=6*250, **kwargs):
         super().__init__(stat_name=stat_name, n_test=n_test, **kwargs)
     
     @staticmethod

--- a/acm/observables/emc/wst_module.py
+++ b/acm/observables/emc/wst_module.py
@@ -81,7 +81,7 @@ class WaveletScatteringTransform(BaseObservableEMC):
         # Define WST configurations to concatenate
         configs = [
             'J4_L4_q1_sigma0.8',
-            # 'J4_L4_q1_sigma1.0',
+            'J4_L4_q1_sigma1.0',
             'J5_L3_q0.8_sigma0.4',
         ]
 
@@ -188,7 +188,7 @@ class WaveletScatteringTransform(BaseObservableEMC):
         # Define WST configurations to concatenate
         configs = [
             'J4_L4_q1_sigma0.8',
-            # 'J4_L4_q1_sigma1.0',
+            'J4_L4_q1_sigma1.0',
             'J5_L3_q0.8_sigma0.4',
         ]
 
@@ -202,7 +202,7 @@ class WaveletScatteringTransform(BaseObservableEMC):
             
             # Get HOD indices from first configuration
             first_config_dir = base_dir / configs[0] / f'c{cosmo_idx:03}_ph{phase:03}' / f'seed{seed}'
-            filenames = sorted(first_config_dir.glob(f'wst_c{cosmo_idx:03}_hod*.npy'))[:n_hod]
+            filenames = sorted(first_config_dir.glob(f'wst_c{cosmo_idx:03}_hod???.npy'))[:n_hod]
             hod_indices = [int(f.stem.split('hod')[-1]) for f in filenames]
             hods[cosmo_idx] = hod_indices
             logger.info(f'Number of HODs: {len(hod_indices)}')


### PR DESCRIPTION
This pull request updates the `WaveletScatteringTransform` module to expand the dataset size and include additional WST configurations in both covariance and data compression. It also refines the file-matching pattern for HOD index extraction to improve accuracy.

**Dataset and configuration updates:**

* Increased the default `n_test` parameter in the `WaveletScatteringTransform` initializer from 750 (6×125) to 1500 (6×250), effectively doubling the number of test samples used.
* Included the `'J4_L4_q1_sigma1.0'` WST configuration in both the `compress_covariance` and `compress_data` functions, allowing more configurations to be concatenated for analysis. [[1]](diffhunk://#diff-c9c887610359345bbad71c1689ab5ddb8d5b9b326121df66055783d5b58f0bfcL84-R84) [[2]](diffhunk://#diff-c9c887610359345bbad71c1689ab5ddb8d5b9b326121df66055783d5b58f0bfcL191-R191)

**File handling improvements:**

* Updated the file glob pattern in `compress_data` to match only files with three-digit HOD indices (using `wst_c{cosmo_idx:03}_hod???.npy`), ensuring more precise selection of HOD files to avoid conflict with other files in the same directories.