### PR TITLE
Update cache key in CI workflow to use pyproject.toml

### DIFF
--- a/.github/workflows/ci-format-tests.yml
+++ b/.github/workflows/ci-format-tests.yml
@@ -30,14 +30,6 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Cache installation
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
-          restore-keys: |
-            ${{ runner.os }}-pip- 
-
       - name: Installation package with editable mode
         run: |
           python -m pip install --upgrade pip
@@ -82,7 +74,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
           restore-keys: |
             ${{ runner.os }}-pip- 
 

--- a/.github/workflows/ci-format-tests.yml
+++ b/.github/workflows/ci-format-tests.yml
@@ -13,6 +13,8 @@ jobs:
   job_format:
     name : Ruff formatter
     runs-on: ubuntu-latest
+    outputs:
+      has_changes: ${{ steps.check_changes.outputs.has_changes }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -46,6 +48,7 @@ jobs:
         run: |
           if  [ -n "$(git status --porcelain)" ]; then
             echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "Changes detected. Skipping tests and pushing changes."
           else
             echo "has_changes=false" >> $GITHUB_OUTPUT
           fi
@@ -61,6 +64,8 @@ jobs:
     name : Pytest runner
     runs-on: ubuntu-latest
     needs: job_format
+    # Formatting changes will trigger a new workflow run, so there is no need to run tests 
+    if: needs.job_format.outputs.has_changes == 'false'
     steps:
       - name: Checkout 
         uses: actions/checkout@v4


### PR DESCRIPTION
Changed the reference file as dependencies are listed in the pyproject files (so that its hash is updated when we update the dependencies)

Also remove caching in format workflow to prevent caching pip env without all dependencies (also the ruff instal is ~4s, I'm not sure the cache will be faster)