### PR TITLE
Reverting to contiguous phase-index for density split covariance

### DIFF
--- a/acm/observables/emc/density_split_module.py
+++ b/acm/observables/emc/density_split_module.py
@@ -85,7 +85,6 @@ class DensitySplitBaseClass(BaseObservableEMC):
         data_fns = sorted(
             base_dir.glob(f"{measurement_root}_poles_ph*.h5")
         )  # NOTE: File name format hardcoded !
-        phase_indices = [int(fn.stem.split("_ph")[-1]) for fn in data_fns]
         n_sims = len(data_fns)
 
         y = []
@@ -105,7 +104,7 @@ class DensitySplitBaseClass(BaseObservableEMC):
         y = xarray.DataArray(
             data=y,
             coords={
-                "phase_idx": phase_indices,
+                "phase_idx": list(range(y.shape[0])),
                 "quantiles": quantiles,
                 "ells": ells,
                 "s": s,


### PR DESCRIPTION
I'm reverting the switch to actual phase-idx for the density split covariance that I merged in the previous PR, as I realized this will cause inconsistencies with other statistics when we run joint fits. We might still want to do this in the future but it needs to be coherent across all statistics and I don't want to re-run all file compressions and potentially breaking people's workflows right now.