### PR TITLE
Enable number density emulator for EMC

### DIFF
--- a/scripts/emc/inference/inference_abacus.py
+++ b/scripts/emc/inference/inference_abacus.py
@@ -3,7 +3,7 @@ from sunbird.inference import priors as sunbird_priors
 from sunbird.cosmology.model_params import get_model_params
 from sunbird.inference.samples import Chain
 
-from acm.observables import CombinedObservable
+from acm.observables import CombinedObservable, Observable
 from acm.utils.covariance import get_covariance_correction
 from acm.utils.modules import get_class_from_module
 from acm import setup_logging
@@ -36,6 +36,11 @@ LEGACY_TO_ALIAS = {
     'VERSUSVoidAutoCorrelationFunctionMultipoles': 'sv_xivv',
     'ReconstructedVERSUSVoidAutoCorrelationFunctionMultipoles': 'sv_recon_xivv',
 }
+
+NBAR_EMULATOR_CHECKPOINT = Path(
+    '/global/cfs/cdirs/desicollab/users/epaillas/acm/emc/models/v1.3/best/number_density.ckpt'
+)
+NBAR_TARGET_DENSITY = 4.85e-4
 
 
 def resolve_statistic_name(statistic: str) -> str:
@@ -136,6 +141,12 @@ def get_observable(observable_names):
         observables.append(obs)
     return obs if len(observables) == 1 else CombinedObservable(observables)
 
+
+def load_number_density_model():
+    """Load the optional EMC number-density emulator checkpoint."""
+    logger.info(f'Loading number density emulator from {NBAR_EMULATOR_CHECKPOINT}')
+    return Observable.load_model(NBAR_EMULATOR_CHECKPOINT)
+
 def get_data_model_cov(observable):
     """
     This function loads the data, covariance matrix, and model prediction
@@ -151,17 +162,17 @@ def get_data_model_cov(observable):
     # load the covariance matrix, including emulator error and Percival correction
     cov = observable.get_covariance_matrix(volume_factor=64)
     logger.info(f'Loaded covariance matrix with shape: {cov.shape}')
-    if args.add_cov_emu:
+    if args.use_emulator_covariance:
         cov += observable.get_emulator_covariance_matrix(
-            method=args.cov_emu_method,
-            diag=args.cov_emu_diag,
+            method=args.emulator_covariance_method,
+            diag=args.use_diagonal_emulator_covariance,
         )
 
     cov *= get_covariance_correction(
         n_s=len(observable.covariance_y),
         n_d=len(cov),
         n_theta=len(data_x_names) - len(fixed_param_names),
-        method=args.cov_correction,
+        method=args.covariance_correction,
     )
 
     # load the model
@@ -190,6 +201,12 @@ def fit_abacus(observable):
     cosmo = fiducial.AbacusSummit(args.cosmo_idx)
     markers.update({'Omega_m': cosmo['Omega_m'], 'h': cosmo['h']})
 
+    number_density_model = None
+    target_density = None
+    if args.use_nbar_emulator:
+        number_density_model = load_number_density_model()
+        target_density = NBAR_TARGET_DENSITY
+
     # sample the posterior
     sampler = PocoMCSampler(
         observation=data_y,
@@ -201,6 +218,8 @@ def fit_abacus(observable):
         labels=labels,
         ellipsoid=True,
         markers=markers,
+        number_density_model=number_density_model,
+        target_density=target_density,
     )
     sampler(vectorize=True, n_total=4096)
 
@@ -239,14 +258,15 @@ if __name__ == "__main__":
     parser.add_argument('-s', '--statistics', nargs='+', help='List of statistics to use, e.g. spectrum')
     parser.add_argument("--cosmo_idx", type=int, default=0)
     parser.add_argument("--hod_idx", type=int, default=0)
-    parser.add_argument('--add_cov_emu', action='store_true', help='Whether to add emulator covariance or not.')
+    parser.add_argument('--use_emulator_covariance', action='store_true', help='Whether to add emulator covariance or not.')
     parser.add_argument('--cosmo_model', type=str, default='base', help='Cosmological model to use.')
     parser.add_argument('--hod_model', type=str, default='base-VB-AB-CB-s', help='HOD model to use.')
     parser.add_argument('--identifier', type=str, default=None, help='Identifier for the run.')
-    parser.add_argument('--cov_emu_method', type=str, default='median', help='Method to compute the emulator covariance.')
-    parser.add_argument('--cov_emu_diag', action='store_true', help='Whether to use only the diagonal of the emulator covariance.')
-    parser.add_argument('--cov_correction', type=str, default='percival', help='Covariance correction method to use.')
-    parser.add_argument('--save_dir', type=str, default='/global/cfs/cdirs/desicollab/users/epaillas/acm/emc/fits/abacus/jan23')
+    parser.add_argument('--emulator_covariance_method', type=str, default='median', help='Method to compute the emulator covariance.')
+    parser.add_argument('--use_diagonal_emulator_covariance', action='store_true', help='Whether to use only the diagonal of the emulator covariance.')
+    parser.add_argument('--covariance_correction', type=str, default='percival', help='Covariance correction method to use.')
+    parser.add_argument('--use_nbar_emulator', action='store_true', help='Enable the EMC number-density emulator constraint during sampling.')
+    parser.add_argument('--save_dir', type=str, default='/global/cfs/cdirs/desicollab/users/epaillas/acm/emc/fits/abacus/apr20')
 
     args = parser.parse_args()
     setup_logging()

--- a/scripts/emc/inference/inference_abacus_greedy.py
+++ b/scripts/emc/inference/inference_abacus_greedy.py
@@ -3,7 +3,7 @@ from sunbird.inference import priors as sunbird_priors
 from sunbird.cosmology.model_params import get_model_params
 from sunbird.inference.samples import Chain
 
-from acm.observables import CombinedObservable
+from acm.observables import CombinedObservable, Observable
 from acm.utils.covariance import get_covariance_correction
 from acm.utils.modules import get_class_from_module
 from acm import setup_logging
@@ -27,6 +27,11 @@ class_names = {
     'ds_xiqq': 'ds_xiqq',
     'pdf': 'pdf',
 }
+
+NBAR_EMULATOR_CHECKPOINT = Path(
+    '/global/cfs/cdirs/desicollab/users/epaillas/acm/emc/models/v1.3/best/number_density.ckpt'
+)
+NBAR_TARGET_DENSITY = 4.85e-4
 
 
 def get_priors(cosmo=True, hod=True):
@@ -122,6 +127,12 @@ def get_observable(stat_names):
         observables.append(obs)
     return obs if len(observables) == 1 else CombinedObservable(observables)
 
+
+def load_number_density_model():
+    """Load the optional EMC number-density emulator checkpoint."""
+    logger.info(f'Loading number density emulator from {NBAR_EMULATOR_CHECKPOINT}')
+    return Observable.load_model(NBAR_EMULATOR_CHECKPOINT)
+
 def get_data_model_cov(observable):
     """
     This function loads the data, covariance matrix, and model prediction
@@ -137,17 +148,17 @@ def get_data_model_cov(observable):
     # load the covariance matrix, including emulator error and Percival correction
     cov = observable.get_covariance_matrix(volume_factor=64)
     logger.info(f'Loaded covariance matrix with shape: {cov.shape}')
-    if args.add_cov_emu:
+    if args.use_emulator_covariance:
         cov += observable.get_emulator_covariance_matrix(
-            method=args.cov_emu_method,
-            diag=args.cov_emu_diag,
+            method=args.emulator_covariance_method,
+            diag=args.use_diagonal_emulator_covariance,
         )
 
     cov *= get_covariance_correction(
         n_s=len(observable.covariance_y),
         n_d=len(cov),
         n_theta=len(data_x_names) - len(fixed_param_names),
-        method=args.cov_correction,
+        method=args.covariance_correction,
     )
 
     # load the model
@@ -176,6 +187,12 @@ def fit_abacus(observable):
     cosmo = fiducial.AbacusSummit(args.cosmo_idx)
     markers.update({'Omega_m': cosmo['Omega_m'], 'h': cosmo['h']})
 
+    number_density_model = None
+    target_density = None
+    if args.use_nbar_emulator:
+        number_density_model = load_number_density_model()
+        target_density = NBAR_TARGET_DENSITY
+
     # sample the posterior
     sampler = PocoMCSampler(
         observation=data_y,
@@ -187,6 +204,8 @@ def fit_abacus(observable):
         labels=labels,
         ellipsoid=True,
         markers=markers,
+        number_density_model=number_density_model,
+        target_density=target_density,
     )
     sampler(vectorize=True, n_total=4096)
 
@@ -222,13 +241,14 @@ if __name__ == "__main__":
     parser.add_argument("--greedy_fn", type=Path, default=Path("/global/u1/e/epaillas/code/acm/scripts/emc/fisher/selected_bins.npy"))
     parser.add_argument("--cosmo_idx", type=int, default=0)
     parser.add_argument("--hod_idx", type=int, default=0)
-    parser.add_argument('--add_cov_emu', action='store_true', help='Whether to add emulator covariance or not.')
+    parser.add_argument('--use_emulator_covariance', action='store_true', help='Whether to add emulator covariance or not.')
     parser.add_argument('--cosmo_model', type=str, default='base', help='Cosmological model to use.')
     parser.add_argument('--hod_model', type=str, default='base-VB-AB-CB-s', help='HOD model to use.')
     parser.add_argument('--identifier', type=str, default=None, help='Identifier for the run.')
-    parser.add_argument('--cov_emu_method', type=str, default='median', help='Method to compute the emulator covariance.')
-    parser.add_argument('--cov_emu_diag', action='store_true', help='Whether to use only the diagonal of the emulator covariance.')
-    parser.add_argument('--cov_correction', type=str, default='percival', help='Covariance correction method to use.')
+    parser.add_argument('--emulator_covariance_method', type=str, default='median', help='Method to compute the emulator covariance.')
+    parser.add_argument('--use_diagonal_emulator_covariance', action='store_true', help='Whether to use only the diagonal of the emulator covariance.')
+    parser.add_argument('--covariance_correction', type=str, default='percival', help='Covariance correction method to use.')
+    parser.add_argument('--use_nbar_emulator', action='store_true', help='Enable the EMC number-density emulator constraint during sampling.')
     parser.add_argument('--save_dir', type=str, default='/global/cfs/cdirs/desicollab/users/epaillas/acm/emc/fits/abacus/greedy/', help='Directory to save the results.')
 
     args = parser.parse_args()

--- a/scripts/emc/training/number_density/plot_number_density_triangle.py
+++ b/scripts/emc/training/number_density/plot_number_density_triangle.py
@@ -1,0 +1,442 @@
+"""
+Triangle plot of predicted galaxy number density in the HOD parameter space.
+
+Loads a trained FCN emulator checkpoint, evaluates it on the full training
+data, and produces a lower-triangular corner scatter plot where each point is
+coloured by the predicted (or true) galaxy number density.
+
+Usage
+-----
+    python plot_ngal_triangle.py --checkpoint /path/to/epoch=X-step=Y.ckpt
+    python plot_ngal_triangle.py --checkpoint model.ckpt --use-truth --output ngal.pdf
+"""
+
+import argparse
+from pathlib import Path
+
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+import cmcrameri.cm as cmc  # registers 'managua' and other scientific colormaps
+import numpy as np
+import torch
+
+from sunbird.emulators import FCN
+from acm.utils.default import cosmo_list
+from acm.utils.abacus import load_abacus_cosmologies
+
+# ---------------------------------------------------------------------------
+# Paths  (mirror train_ngal.py)
+# ---------------------------------------------------------------------------
+COSMO_FILE = Path('/pscratch/sd/e/epaillas/emc/AbacusSummit.csv')
+HOD_PARAMS_FILE = Path('/pscratch/sd/n/ntbfin/emulator/hods/hod_params.npy')
+NGAL_FILE = Path('/pscratch/sd/n/ntbfin/emulator/hods/n_gal.npy')
+
+COSMO_PARAM_NAMES = ['omega_b', 'omega_cdm', 'sigma8_m', 'n_s', 'alpha_s', 'N_ur', 'w0_fld', 'wa_fld']
+COSMO_PARAMS_MAPPING = {'alpha_s': 'nrun'}
+
+# Target observed number density (used to centre the diverging colour scale)
+TARGET_DENSITY = 4.85e-4
+
+
+# Number of leading cosmological parameters to skip when plotting
+N_COSMO_PARAMS = len(COSMO_PARAM_NAMES)
+
+LABELS = {
+    'omega_b':   r'$\omega_{\rm b}$',
+    'omega_cdm': r'$\omega_{\rm cdm}$',
+    'sigma8_m':  r'$\sigma_8$',
+    'n_s':       r'$n_s$',
+    'nrun':      r'$\alpha_s$',
+    'N_ur':      r'$N_{\rm ur}$',
+    'w0_fld':    r'$w_0$',
+    'wa_fld':    r'$w_a$',
+    'logM_1':    r'$\log M_1$',
+    'logM_cut':  r'$\log M_{\rm cut}$',
+    'alpha':     r'$\alpha$',
+    'alpha_s':   r'$\alpha_{\rm vel, s}$',
+    'alpha_c':   r'$\alpha_{\rm vel, c}$',
+    'sigma':     r'$\log \sigma$',
+    'kappa':     r'$\kappa$',
+    'A_cen':     r'$A_{\rm cen}$',
+    'A_sat':     r'$A_{\rm sat}$',
+    'B_cen':     r'$B_{\rm cen}$',
+    'B_sat':     r'$B_{\rm sat}$',
+    's':         r'$s$',
+    'fsigma8':   r'$f \sigma_8$',
+    'Omega_m':   r'$\Omega_{\rm m}$',
+    'H0':        r'$H_0$',
+}
+
+
+def get_x_and_names(cosmo_indices=None):
+    """Build the input feature matrix and the ordered list of parameter names.
+
+    Parameters
+    ----------
+    cosmo_indices : list of int or None, optional
+        Subset of cosmology indices to load. Defaults to the full ``cosmo_list``.
+
+    Returns
+    -------
+    x : np.ndarray
+        2-D array of shape ``(N_samples, N_cosmo_params + N_hod_params)``.
+    param_names : list of str
+        Ordered list of parameter names matching the columns of ``x``.
+    """
+    if cosmo_indices is None:
+        cosmo_indices = cosmo_list
+
+    cosmo_params = load_abacus_cosmologies(
+        COSMO_FILE,
+        cosmologies=cosmo_indices,
+        parameters=COSMO_PARAM_NAMES,
+        mapping=COSMO_PARAMS_MAPPING,
+    )
+
+    # Enforce parameter ordering after renaming
+    x_cosmo_names = COSMO_PARAM_NAMES.copy()
+    for key, value in COSMO_PARAMS_MAPPING.items():
+        x_cosmo_names[x_cosmo_names.index(key)] = value
+
+    hod_params = np.load(HOD_PARAMS_FILE, allow_pickle=True).item()
+
+    x, hod_names = [], None
+    for cosmo_idx in cosmo_indices:
+        x_hod_dict = hod_params[f'c{cosmo_idx:03}']
+        if hod_names is None:
+            hod_names = list(x_hod_dict.keys())
+        x_hod = np.array([x_hod_dict[p] for p in hod_names]).T  # (N_hod, N_hod_params)
+
+        x_cosmo = cosmo_params[f'c{cosmo_idx:03}']
+        x_cosmo = np.array([x_cosmo[p] for p in x_cosmo_names])
+        x_cosmo = np.repeat(x_cosmo.reshape(1, -1), x_hod.shape[0], axis=0)
+
+        x.append(np.concatenate([x_cosmo, x_hod], axis=1))
+
+    param_names = x_cosmo_names + hod_names
+    return np.concatenate(x), param_names
+
+
+def get_y(cosmo_indices=None):
+    """Load the true galaxy number density values.
+
+    Parameters
+    ----------
+    cosmo_indices : list of int or None, optional
+        Subset of cosmology indices to load. Defaults to the full ``cosmo_list``.
+
+    Returns
+    -------
+    np.ndarray
+        1-D array of shape ``(N_samples,)`` containing the galaxy number density.
+    """
+    if cosmo_indices is None:
+        cosmo_indices = cosmo_list
+    data = np.load(NGAL_FILE, allow_pickle=True).item()
+    y = np.concatenate([data[f'c{cosmo_idx:03}'] for cosmo_idx in cosmo_indices])
+    return y.ravel()
+
+
+def load_model(checkpoint_path: str) -> FCN:
+    """Load a trained FCN emulator from a Lightning checkpoint.
+
+    Parameters
+    ----------
+    checkpoint_path : str
+        Path to the ``.ckpt`` file produced during training.
+
+    Returns
+    -------
+    FCN
+        Emulator in evaluation mode on CPU.
+    """
+    model = FCN.load_from_checkpoint(checkpoint_path, strict=True)
+    model.eval().to('cpu')
+    return model
+
+
+def make_triangle_plot(
+    x: np.ndarray,
+    y: np.ndarray,
+    param_names: list,
+    skip_cosmo: bool = True,
+    ndim: int | None = None,
+    cmap_name: str = 'managua',
+    point_size: float = 0.5,
+    colorbar_label: str = r'$n_{\rm gal}$',
+    title: str = 'Galaxy number density — HOD parameter space',
+    target_density: float | None = TARGET_DENSITY,
+) -> plt.Figure:
+    """Create a lower-triangular corner scatter plot.
+
+    Each panel shows a 2-D projection of the parameter space, with points
+    coloured by the galaxy number density ``y``.
+
+    When ``target_density`` is set the colour scale uses
+    `~matplotlib.colors.TwoSlopeNorm` centred at that value so regions
+    above and below are immediately distinguishable.  A dashed line is
+    also drawn on the colourbar at the target value.
+
+    Parameters
+    ----------
+    x : np.ndarray
+        Input feature matrix of shape ``(N_samples, N_params)``.
+    y : np.ndarray
+        1-D array of colour values (number density), shape ``(N_samples,)``.
+    param_names : list of str
+        Ordered parameter names matching the columns of ``x``.
+    skip_cosmo : bool, optional
+        If ``True`` (default), skip the first ``N_COSMO_PARAMS`` columns and
+        show only HOD parameters.
+    ndim : int or None, optional
+        Number of HOD parameters to include in the plot. Defaults to all
+        available HOD parameters.
+    cmap_name : str, optional
+        Matplotlib colour map name (default ``'managua'``).
+    point_size : float, optional
+        Scatter point size (default ``0.5``).
+    colorbar_label : str, optional
+        Label for the colour bar.
+    title : str, optional
+        Figure suptitle.
+    target_density : float or None, optional
+        Observed galaxy number density used to centre the diverging colour
+        scale. Set to ``None`` to use a linear norm instead.
+
+    Returns
+    -------
+    matplotlib.figure.Figure
+    """
+    skip = N_COSMO_PARAMS if skip_cosmo else 0
+    available = len(param_names) - skip
+    if ndim is None:
+        ndim = available
+    ndim = min(ndim, available)
+
+    param_indices = list(range(skip, skip + ndim))
+    plot_names = [param_names[i] for i in param_indices]
+
+    cmap = mpl.colormaps[cmap_name]
+    if target_density is not None:
+        vmin, vmax = y.min(), y.max()
+        # Clamp vcenter so TwoSlopeNorm never fails if target is outside range
+        vcenter = float(np.clip(target_density, vmin + 1e-30, vmax - 1e-30))
+        norm = mpl.colors.TwoSlopeNorm(vcenter=vcenter, vmin=vmin, vmax=vmax)
+    else:
+        norm = mpl.colors.Normalize(vmin=y.min(), vmax=y.max())
+
+    fig, axes = plt.subplots(ndim, ndim, figsize=(2 * ndim, 2 * ndim))
+
+    for i, ipar in enumerate(param_indices):
+        for j, jpar in enumerate(param_indices):
+            ax = axes[i][j]
+
+            if i < j:
+                # Upper triangle — remove the axis
+                fig.delaxes(ax)
+                continue
+
+            ax.scatter(
+                x[:, jpar],
+                x[:, ipar],
+                c=cmap(norm(y)),
+                s=point_size,
+                rasterized=True,
+            )
+
+            # Axis labels only on the outer edges
+            if i == ndim - 1:
+                ax.set_xlabel(LABELS.get(plot_names[j], plot_names[j]), fontsize=15)
+            else:
+                ax.xaxis.set_visible(False)
+
+            if j == 0:
+                ax.set_ylabel(LABELS.get(plot_names[i], plot_names[i]), fontsize=15)
+            else:
+                ax.yaxis.set_visible(False)
+
+            ax.tick_params(labelsize=12)
+
+    # Colour bar spanning the full figure height
+    sm = mpl.cm.ScalarMappable(cmap=cmap, norm=norm)
+    sm.set_array([])
+    cbar = fig.colorbar(sm, ax=axes, fraction=0.03, pad=0.02)
+    cbar.set_label(colorbar_label, fontsize=18)
+    cbar.ax.tick_params(labelsize=15)
+
+    if isinstance(norm, mpl.colors.TwoSlopeNorm):
+        # Explicit ticks: 5 evenly spaced on each side of vcenter,
+        # plus vcenter itself — guarantees both halves are labelled
+        # regardless of how compressed one half is.
+        n_ticks = 5
+        lower_ticks = np.linspace(norm.vmin, norm.vcenter, n_ticks, endpoint=False)
+        upper_ticks = np.linspace(norm.vcenter, norm.vmax, n_ticks + 1)
+        ticks = np.concatenate([lower_ticks, upper_ticks])
+        cbar.set_ticks(ticks)
+        cbar.set_ticklabels([f'{t:.1e}' for t in ticks])
+
+    fig.suptitle(title, fontsize=25, y=0.9)
+    return fig
+
+
+def parse_args():
+    """Parse command-line arguments.
+
+    Returns
+    -------
+    argparse.Namespace
+        Parsed arguments:
+
+        ``checkpoint`` : str
+            Path to the trained FCN ``.ckpt`` file.
+        ``output`` : str
+            Output figure file (default: ``ngal_triangle.pdf``).
+        ``use_truth`` : bool
+            Colour points by ground-truth ``n_gal`` instead of model predictions.
+        ``ndim`` : int or None
+            Number of HOD dimensions to display (default: all).
+        ``point_size`` : float
+            Scatter marker size.
+        ``cmap`` : str
+            Matplotlib colour map name.
+        ``include_cosmo`` : bool
+            If set, include cosmological parameters in the triangle plot.
+    """
+    parser = argparse.ArgumentParser(
+        description='Triangle plot of n_gal predictions in the HOD parameter space.'
+    )
+    parser.add_argument(
+        '--checkpoint',
+        type=str,
+        required=True,
+        help='Path to the trained FCN checkpoint (.ckpt).',
+    )
+    parser.add_argument(
+        '--output',
+        type=str,
+        default='ngal_triangle.pdf',
+        help='Output figure filename (default: ngal_triangle.pdf).',
+    )
+    parser.add_argument(
+        '--use-truth',
+        action='store_true',
+        default=False,
+        help='Colour points by ground-truth n_gal instead of model predictions.',
+    )
+    parser.add_argument(
+        '--ndim',
+        type=int,
+        default=None,
+        help='Number of HOD dimensions to include in the plot (default: all).',
+    )
+    parser.add_argument(
+        '--point-size',
+        type=float,
+        default=0.5,
+        help='Scatter marker size (default: 0.5).',
+    )
+    parser.add_argument(
+        '--cmap',
+        type=str,
+        default='managua_r',
+        help='Matplotlib colour map name (default: managua).',
+    )
+    parser.add_argument(
+        '--target-density',
+        type=float,
+        default=TARGET_DENSITY,
+        metavar='N_GAL',
+        help=(
+            'Observed galaxy number density used to centre the diverging colour scale '
+            f'(default: {TARGET_DENSITY:.2e}). Pass 0 to disable.'
+        ),
+    )
+    parser.add_argument(
+        '--include-cosmo',
+        action='store_true',
+        default=False,
+        help='Include cosmological parameters in the triangle plot.',
+    )
+    parser.add_argument(
+        '--cosmo-idx',
+        type=int,
+        default=None,
+        metavar='IDX',
+        help=(
+            'Restrict the plot to a single AbacusSummit cosmology index '
+            '(e.g. 0 for c000). Defaults to all cosmologies.'
+        ),
+    )
+    return parser.parse_args()
+
+
+def main():
+    """Load model, run predictions, and save the triangle plot."""
+    args = parse_args()
+
+    # ------------------------------------------------------------------
+    # Resolve which cosmologies to load
+    # ------------------------------------------------------------------
+    if args.cosmo_idx is not None:
+        if args.cosmo_idx not in cosmo_list:
+            raise ValueError(
+                f'cosmo_idx {args.cosmo_idx} is not in cosmo_list. '
+                f'Available indices: {cosmo_list}'
+            )
+        cosmo_indices = [args.cosmo_idx]
+        print(f'Restricting to cosmology c{args.cosmo_idx:03}.')
+    else:
+        cosmo_indices = None  # use full cosmo_list inside helpers
+
+    # ------------------------------------------------------------------
+    # Data
+    # ------------------------------------------------------------------
+    print('Loading data...')
+    x, param_names = get_x_and_names(cosmo_indices=cosmo_indices)
+    y_truth = get_y(cosmo_indices=cosmo_indices)
+    print(f'  x shape: {x.shape}  |  y shape: {y_truth.shape}')
+    print(f'  Parameters: {param_names}')
+
+    # ------------------------------------------------------------------
+    # Model predictions
+    # ------------------------------------------------------------------
+    if args.use_truth:
+        print('Using ground-truth n_gal for colouring.')
+        y_plot = y_truth
+        colorbar_label = r'$n_{\rm gal}$ (truth)'
+    else:
+        print(f'Loading model from {args.checkpoint} ...')
+        model = load_model(args.checkpoint)
+        with torch.no_grad():
+            y_plot = model.get_prediction(torch.Tensor(x)).numpy().ravel()
+        print(f'  Predictions range: [{y_plot.min():.4e}, {y_plot.max():.4e}]')
+        colorbar_label = r'$n_{\rm gal}$ (predicted)'
+
+    # ------------------------------------------------------------------
+    # Triangle plot
+    # ------------------------------------------------------------------
+    cosmo_label = f'c{args.cosmo_idx:03}' if args.cosmo_idx is not None else 'all cosmologies'
+    title = f'Galaxy number density — HOD parameter space ({cosmo_label})'
+
+    print('Making triangle plot...')
+    fig = make_triangle_plot(
+        x=x,
+        y=y_plot,
+        param_names=param_names,
+        skip_cosmo=not args.include_cosmo,
+        ndim=args.ndim,
+        cmap_name=args.cmap,
+        point_size=args.point_size,
+        colorbar_label=colorbar_label,
+        title=title,
+        target_density=args.target_density if args.target_density != 0 else None,
+    )
+
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output, bbox_inches='tight', dpi=150)
+    print(f'Saved figure to {output}')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/emc/training/number_density/train_number_density.py
+++ b/scripts/emc/training/number_density/train_number_density.py
@@ -1,0 +1,287 @@
+"""
+Train an emulator for the galaxy number density.
+
+The emulator is a fully connected network (FCN) that maps cosmological and HOD
+parameters to the galaxy number density. Training data are drawn from the
+AbacusSummit simulation HOD catalogs constructed with the ACM pipeline.
+"""
+
+import argparse
+import numpy as np
+from pathlib import Path
+from sunbird.emulators import FCN, train
+from sunbird.data import ArrayDataModule
+from sunbird.data.transforms_array import LogTransform, ArcsinhTransform
+from acm.utils.default import cosmo_list  # List of cosmologies in AbacusSummit
+from acm.utils.abacus import load_abacus_cosmologies
+import torch
+torch.set_float32_matmul_precision('high')
+
+# ---------------------------------------------------------------------------
+# Hardcoded paths
+# ---------------------------------------------------------------------------
+COSMO_FILE = Path('/pscratch/sd/e/epaillas/emc/AbacusSummit.csv')
+HOD_PARAMS_FILE = Path('/pscratch/sd/n/ntbfin/emulator/hods/hod_params.npy')
+NGAL_FILE = Path('/pscratch/sd/n/ntbfin/emulator/hods/n_gal.npy')
+
+# ---------------------------------------------------------------------------
+# Cosmological parameter configuration
+# ---------------------------------------------------------------------------
+COSMO_PARAM_NAMES = ['omega_b', 'omega_cdm', 'sigma8_m', 'n_s', 'alpha_s', 'N_ur', 'w0_fld', 'wa_fld']
+COSMO_PARAMS_MAPPING = {'alpha_s': 'nrun'}
+
+# ---------------------------------------------------------------------------
+# Statistic label
+# ---------------------------------------------------------------------------
+STATISTIC = 'number_density_downsampled'
+
+
+def get_x():
+    """Build the input feature matrix X for the emulator.
+
+    For each cosmology in ``cosmo_list``, the function concatenates the
+    cosmological parameters (broadcast to every HOD realisation) with the
+    corresponding HOD parameters, producing one row per (cosmology, HOD) pair.
+
+    Returns
+    -------
+    x : np.ndarray
+        2-D array of shape ``(N_samples, N_cosmo_params + N_hod_params)``
+        containing the concatenated input features.
+    cosmo_labels : np.ndarray of int, shape (N_samples,)
+        Cosmology index for each row, used to build cosmology-level splits.
+    """
+    cosmo_params = load_abacus_cosmologies(
+        COSMO_FILE,
+        cosmologies=cosmo_list,
+        parameters=COSMO_PARAM_NAMES,
+        mapping=COSMO_PARAMS_MAPPING,
+    )
+
+    # Enforce parameter ordering after renaming via the mapping
+    x_cosmo_names = COSMO_PARAM_NAMES.copy()
+    for key, value in COSMO_PARAMS_MAPPING.items():
+        x_cosmo_names[x_cosmo_names.index(key)] = value
+
+    hod_params = np.load(HOD_PARAMS_FILE, allow_pickle=True).item()
+
+    x, cosmo_labels = [], []
+    for cosmo_idx in cosmo_list:
+        # HOD parameters: dict → array of shape (N_hod, N_hod_params)
+        x_hod = hod_params[f'c{cosmo_idx:03}']
+        x_hod = np.array([x_hod[param] for param in x_hod.keys()]).T
+
+        # Cosmological parameters: broadcast to match HOD realisations
+        x_cosmo = cosmo_params[f'c{cosmo_idx:03}']
+        x_cosmo = np.array([x_cosmo[param] for param in x_cosmo_names])
+        x_cosmo = np.repeat(x_cosmo.reshape(1, -1), x_hod.shape[0], axis=0)
+
+        x.append(np.concatenate([x_cosmo, x_hod], axis=1))
+        cosmo_labels.append(np.full(x_hod.shape[0], cosmo_idx, dtype=int))
+
+    return np.concatenate(x), np.concatenate(cosmo_labels)
+
+
+def get_y():
+    """Load the target galaxy number density values.
+
+    Returns
+    -------
+    np.ndarray
+        2-D array of shape ``(N_samples, 1)`` containing the galaxy number
+        density for each (cosmology, HOD) pair.
+    """
+    data = np.load(NGAL_FILE, allow_pickle=True).item()
+    y = np.concatenate([data[f'c{cosmo_idx:03}'] for cosmo_idx in cosmo_list])
+    return y.reshape(-1, 1)
+
+
+def parse_args():
+    """Parse command-line arguments.
+
+    Returns
+    -------
+    argparse.Namespace
+        Parsed arguments with the following attributes:
+
+        ``model_dir`` : str
+            Directory where model checkpoints and logs are saved.
+        ``max_epochs`` : int
+            Maximum number of training epochs.
+        ``batch_size`` : int
+            Mini-batch size used during training.
+        ``learning_rate`` : float
+            Initial learning rate for the Adam optimiser.
+        ``devices`` : int
+            Number of GPU (or CPU) devices to use for training.
+        ``n_hidden`` : list of int
+            Hidden layer widths of the FCN.
+        ``val_cosmo_fraction`` : float
+            Fraction of cosmologies held out for validation.
+        ``weight_decay`` : float
+            L2 regularisation strength.
+    """
+    parser = argparse.ArgumentParser(
+        description='Train an FCN emulator for the galaxy number density.'
+    )
+    parser.add_argument(
+        '--model-dir',
+        type=str,
+        default='./',
+        help='Directory to save model checkpoints and TensorBoard logs (default: ./)',
+    )
+    parser.add_argument(
+        '--max-epochs',
+        type=int,
+        default=5000,
+        help='Maximum number of training epochs (default: 5000)',
+    )
+    parser.add_argument(
+        '--batch-size',
+        type=int,
+        default=512,
+        help='Mini-batch size (default: 512)',
+    )
+    parser.add_argument(
+        '--learning-rate',
+        type=float,
+        default=1e-3,
+        help='Initial learning rate (default: 1e-3)',
+    )
+    parser.add_argument(
+        '--devices',
+        type=int,
+        default=1,
+        help='Number of devices (GPUs/CPUs) to use for training (default: 1)',
+    )
+    parser.add_argument(
+        '--transform',
+        type=str,
+        choices=['log', 'arcsinh'],
+        default=None,
+        help='Output transform to apply to n_gal before training (default: none).',
+    )
+    parser.add_argument(
+        '--n-hidden',
+        type=int,
+        nargs='+',
+        default=[256, 256, 256],
+        metavar='N',
+        help='Hidden layer widths, e.g. --n-hidden 256 256 256 (default: 256 256 256)',
+    )
+    parser.add_argument(
+        '--val-cosmo-fraction',
+        type=float,
+        default=0.1,
+        help='Fraction of cosmologies to hold out for validation (default: 0.1)',
+    )
+    parser.add_argument(
+        '--weight-decay',
+        type=float,
+        default=0.0,
+        help='L2 regularisation strength (default: 0.0)',
+    )
+    return parser.parse_args()
+
+
+def main():
+    """Train the galaxy number density emulator end-to-end."""
+    args = parse_args()
+    model_dir = Path(args.model_dir)
+    model_dir.mkdir(parents=True, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    # Load training data
+    # ------------------------------------------------------------------
+    x, cosmo_labels = get_x()
+    y = get_y()
+    print(f'Loaded data with shape: x={x.shape}, y={y.shape}')
+
+    # ------------------------------------------------------------------
+    # Cosmology-level train/val split
+    # ------------------------------------------------------------------
+    n_val_cosmo = max(1, int(len(cosmo_list) * args.val_cosmo_fraction))
+    val_cosmos  = set(cosmo_list[:n_val_cosmo])
+    train_cosmos = set(cosmo_list[n_val_cosmo:])
+    val_idx   = np.where(np.isin(cosmo_labels, list(val_cosmos)))[0].tolist()
+    train_idx = np.where(np.isin(cosmo_labels, list(train_cosmos)))[0].tolist()
+    print(f'Validation cosmologies ({n_val_cosmo}): {sorted(val_cosmos)}')
+    print(f'Training cosmologies  ({len(train_cosmos)}): {sorted(train_cosmos)}')
+
+    # ------------------------------------------------------------------
+    # Optional output transform
+    # ------------------------------------------------------------------
+    if args.transform == 'log':
+        transform = LogTransform()
+    elif args.transform == 'arcsinh':
+        transform = ArcsinhTransform()
+    else:
+        transform = None
+
+    if transform is not None:
+        print(f'Applying {args.transform} transform to outputs.')
+        y = transform.transform(y)
+
+    # ------------------------------------------------------------------
+    # Set up PyTorch Lightning data module
+    # ------------------------------------------------------------------
+    data = ArrayDataModule(
+        x=torch.Tensor(x),
+        y=torch.Tensor(y),
+        val_idx=val_idx,
+        batch_size=args.batch_size,
+        num_workers=0,
+    )
+    data.setup()
+
+    # ------------------------------------------------------------------
+    # Compute normalisation statistics from the training split only
+    # ------------------------------------------------------------------
+    x_train = data.ds_train.tensors[0].numpy()
+    y_train = data.ds_train.tensors[1].numpy()
+    mean_x, std_x = x_train.mean(axis=0), x_train.std(axis=0)
+    mean_y, std_y = y_train.mean(axis=0), y_train.std(axis=0)
+
+    # ------------------------------------------------------------------
+    # Build the fully connected network
+    # ------------------------------------------------------------------
+    model = FCN(
+        n_input=data.n_input,
+        n_output=data.n_output,
+        n_hidden=args.n_hidden,
+        dropout_rate=0.0,
+        learning_rate=args.learning_rate,
+        scheduler_patience=100,
+        scheduler_factor=0.5,
+        scheduler_threshold=1e-5,
+        weight_decay=args.weight_decay,
+        act_fn='learned_sigmoid',
+        loss='mae',
+        training=True,
+        transform_output=transform,
+        mean_input=mean_x,
+        std_input=std_x,
+        mean_output=mean_y,
+        std_output=std_y,
+        standarize_output=True,
+    )
+
+    # ------------------------------------------------------------------
+    # Train
+    # ------------------------------------------------------------------
+    val_loss, model, early_stop_callback = train.fit(
+        data=data,
+        model=model,
+        model_dir=str(model_dir),
+        max_epochs=args.max_epochs,
+        devices=args.devices,
+        logger='tensorboard',
+        log_dir=str(model_dir),
+    )
+
+    print(f'Training complete. Best validation loss: {val_loss:.6f}')
+    print(f'Model saved to: {model_dir}')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/emc/training/number_density/validate_number_density.py
+++ b/scripts/emc/training/number_density/validate_number_density.py
@@ -1,0 +1,480 @@
+"""
+Validate the accuracy of the galaxy number density emulator.
+
+Loads a trained FCN checkpoint and the original simulation data, runs
+predictions over the full data set, computes summary error statistics, and
+produces a set of diagnostic plots:
+
+  1. Predicted vs. truth scatter (1-to-1 diagonal).
+  2. Fractional residual distribution (histogram).
+  3. Fractional residual as a function of the true n_gal.
+  4. Per-cosmology MAE summary.
+
+Usage
+-----
+    python validate_ngal.py --checkpoint /path/to/epoch=X-step=Y.ckpt
+    python validate_ngal.py --checkpoint model.ckpt --output-dir ./validation/
+    python validate_ngal.py --checkpoint model.ckpt --cosmo-idx 0
+"""
+
+import argparse
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import matplotlib as mpl
+import numpy as np
+import torch
+
+from acm.utils.abacus import load_abacus_cosmologies
+from acm.utils.default import cosmo_list
+from sunbird.emulators import FCN
+
+# ---------------------------------------------------------------------------
+# Paths  (mirror train_ngal.py)
+# ---------------------------------------------------------------------------
+COSMO_FILE = Path('/pscratch/sd/e/epaillas/emc/AbacusSummit.csv')
+HOD_PARAMS_FILE = Path('/pscratch/sd/n/ntbfin/emulator/hods/hod_params.npy')
+NGAL_FILE = Path('/pscratch/sd/n/ntbfin/emulator/hods/n_gal.npy')
+
+COSMO_PARAM_NAMES = ['omega_b', 'omega_cdm', 'sigma8_m', 'n_s', 'alpha_s', 'N_ur', 'w0_fld', 'wa_fld']
+COSMO_PARAMS_MAPPING = {'alpha_s': 'nrun'}
+
+
+# ---------------------------------------------------------------------------
+# Data helpers
+# ---------------------------------------------------------------------------
+
+def get_x(cosmo_indices=None):
+    """Build the input feature matrix for the given cosmologies.
+
+    Parameters
+    ----------
+    cosmo_indices : list of int or None
+        Subset of cosmology indices to load. Defaults to the full
+        ``cosmo_list``.
+
+    Returns
+    -------
+    x : np.ndarray, shape (N, N_params)
+    cosmo_labels : np.ndarray of int, shape (N,)
+        Cosmology index for each row, useful for per-cosmology diagnostics.
+    """
+    if cosmo_indices is None:
+        cosmo_indices = cosmo_list
+
+    cosmo_params = load_abacus_cosmologies(
+        COSMO_FILE,
+        cosmologies=cosmo_indices,
+        parameters=COSMO_PARAM_NAMES,
+        mapping=COSMO_PARAMS_MAPPING,
+    )
+
+    x_cosmo_names = COSMO_PARAM_NAMES.copy()
+    for key, value in COSMO_PARAMS_MAPPING.items():
+        x_cosmo_names[x_cosmo_names.index(key)] = value
+
+    hod_params = np.load(HOD_PARAMS_FILE, allow_pickle=True).item()
+
+    x, cosmo_labels = [], []
+    for cosmo_idx in cosmo_indices:
+        x_hod_dict = hod_params[f'c{cosmo_idx:03}']
+        x_hod = np.array([x_hod_dict[p] for p in x_hod_dict.keys()]).T
+
+        x_cosmo = cosmo_params[f'c{cosmo_idx:03}']
+        x_cosmo = np.array([x_cosmo[p] for p in x_cosmo_names])
+        x_cosmo = np.repeat(x_cosmo.reshape(1, -1), x_hod.shape[0], axis=0)
+
+        x.append(np.concatenate([x_cosmo, x_hod], axis=1))
+        cosmo_labels.append(np.full(x_hod.shape[0], cosmo_idx, dtype=int))
+
+    return np.concatenate(x), np.concatenate(cosmo_labels)
+
+
+def get_y(cosmo_indices=None):
+    """Load the true galaxy number density values.
+
+    Parameters
+    ----------
+    cosmo_indices : list of int or None
+        Subset of cosmology indices. Defaults to the full ``cosmo_list``.
+
+    Returns
+    -------
+    np.ndarray, shape (N,)
+    """
+    if cosmo_indices is None:
+        cosmo_indices = cosmo_list
+    data = np.load(NGAL_FILE, allow_pickle=True).item()
+    y = np.concatenate([data[f'c{cosmo_idx:03}'] for cosmo_idx in cosmo_indices])
+    return y.ravel()
+
+
+def load_model(checkpoint_path: str) -> FCN:
+    """Load a trained FCN emulator from a Lightning checkpoint.
+
+    Parameters
+    ----------
+    checkpoint_path : str
+        Path to the ``.ckpt`` file.
+
+    Returns
+    -------
+    FCN
+        Model in evaluation mode on CPU.
+    """
+    model = FCN.load_from_checkpoint(
+        checkpoint_path, strict=True, weights_only=False
+    )
+    model.eval().to('cpu')
+    return model
+
+
+# ---------------------------------------------------------------------------
+# Metrics
+# ---------------------------------------------------------------------------
+
+def compute_metrics(y_true: np.ndarray, y_pred: np.ndarray) -> dict:
+    """Compute scalar accuracy metrics.
+
+    Parameters
+    ----------
+    y_true : np.ndarray, shape (N,)
+    y_pred : np.ndarray, shape (N,)
+
+    Returns
+    -------
+    dict with keys: mae, rmse, rel_err_median, rel_err_p16, rel_err_p84, r2
+    """
+    residuals = y_pred - y_true
+    frac_residuals = residuals / np.abs(y_true)
+
+    ss_res = np.sum(residuals ** 2)
+    ss_tot = np.sum((y_true - y_true.mean()) ** 2)
+
+    return {
+        'mae':            float(np.mean(np.abs(residuals))),
+        'rmse':           float(np.sqrt(np.mean(residuals ** 2))),
+        'rel_err_median': float(np.median(frac_residuals) * 100),
+        'rel_err_p16':    float(np.percentile(frac_residuals, 16) * 100),
+        'rel_err_p84':    float(np.percentile(frac_residuals, 84) * 100),
+        'r2':             float(1.0 - ss_res / ss_tot),
+    }
+
+
+def print_metrics(metrics: dict, label: str = 'All cosmologies') -> None:
+    """Pretty-print a metrics dict returned by :func:`compute_metrics`."""
+    print(f'\n--- {label} ---')
+    print(f"  MAE                : {metrics['mae']:.4e}")
+    print(f"  RMSE               : {metrics['rmse']:.4e}")
+    print(f"  Rel. error (median): {metrics['rel_err_median']:+.3f} %")
+    print(f"  Rel. error (16-84) : {metrics['rel_err_p16']:.3f} % to {metrics['rel_err_p84']:.3f} %")
+    print(f"  R²                 : {metrics['r2']:.6f}")
+
+
+# ---------------------------------------------------------------------------
+# Plots
+# ---------------------------------------------------------------------------
+
+def plot_pred_vs_truth(y_true, y_pred, output_path, title=''):
+    """Scatter plot of predicted vs. true n_gal with residual panel.
+
+    Parameters
+    ----------
+    y_true, y_pred : np.ndarray, shape (N,)
+    output_path : Path
+    title : str
+    """
+    frac_res = (y_pred - y_true) / np.abs(y_true) * 100  # percent
+
+    fig, axes = plt.subplots(2, 1, figsize=(5, 7),
+                             gridspec_kw={'height_ratios': [3, 1.2]},
+                             sharex=False)
+
+    # --- Top panel: pred vs truth ---
+    ax = axes[0]
+    lims = [min(y_true.min(), y_pred.min()) * 0.98,
+            max(y_true.max(), y_pred.max()) * 1.02]
+    ax.plot(lims, lims, 'k--', lw=1, label='1:1')
+    ax.scatter(y_true, y_pred, s=1.5, alpha=0.4, rasterized=True, color='steelblue')
+    ax.set_xlim(lims)
+    ax.set_ylim(lims)
+    ax.set_xlabel(r'$n_{\rm gal}$ (truth)', fontsize=11)
+    ax.set_ylabel(r'$n_{\rm gal}$ (predicted)', fontsize=11)
+    ax.legend(fontsize=9)
+    if title:
+        ax.set_title(title, fontsize=10)
+
+    # Annotate with R²
+    metrics = compute_metrics(y_true, y_pred)
+    ax.text(0.05, 0.93, f"$R^2 = {metrics['r2']:.5f}$",
+            transform=ax.transAxes, fontsize=9, va='top')
+
+    # --- Bottom panel: fractional residuals vs truth ---
+    ax2 = axes[1]
+    ax2.axhline(0, color='k', lw=1, ls='--')
+    ax2.scatter(y_true, frac_res, s=1.5, alpha=0.4, rasterized=True, color='steelblue')
+    ax2.set_xlabel(r'$n_{\rm gal}$ (truth)', fontsize=11)
+    ax2.set_ylabel(r'$\Delta n_{\rm gal} / n_{\rm gal}$ [%]', fontsize=9)
+
+    plt.tight_layout()
+    fig.savefig(output_path, bbox_inches='tight', dpi=150)
+    plt.close(fig)
+    print(f'  Saved: {output_path}')
+
+
+def plot_residual_histogram(y_true, y_pred, output_path, title=''):
+    """Histogram of fractional residuals.
+
+    Parameters
+    ----------
+    y_true, y_pred : np.ndarray, shape (N,)
+    output_path : Path
+    title : str
+    """
+    frac_res = (y_pred - y_true) / np.abs(y_true) * 100  # percent
+
+    fig, ax = plt.subplots(figsize=(5, 4))
+    ax.hist(frac_res, bins=60, color='steelblue', edgecolor='white', linewidth=0.3)
+    ax.axvline(0, color='k', lw=1, ls='--')
+    ax.axvline(np.percentile(frac_res, 16), color='tomato', lw=1, ls=':', label='16th / 84th pct')
+    ax.axvline(np.percentile(frac_res, 84), color='tomato', lw=1, ls=':')
+    ax.axvline(np.median(frac_res), color='darkorange', lw=1.5, ls='-', label='Median')
+    ax.set_xlabel(r'$(n_{\rm gal,pred} - n_{\rm gal,true})\,/\,n_{\rm gal,true}$ [%]', fontsize=10)
+    ax.set_ylabel('Count', fontsize=10)
+    ax.legend(fontsize=8)
+    if title:
+        ax.set_title(title, fontsize=10)
+    plt.tight_layout()
+    fig.savefig(output_path, bbox_inches='tight', dpi=150)
+    plt.close(fig)
+    print(f'  Saved: {output_path}')
+
+
+def plot_per_cosmo_mae(y_true, y_pred, cosmo_labels, cosmo_indices, output_path, title=''):
+    """Bar chart of per-cosmology MAE.
+
+    Parameters
+    ----------
+    y_true, y_pred : np.ndarray, shape (N,)
+    cosmo_labels : np.ndarray of int, shape (N,)
+    cosmo_indices : list of int
+    output_path : Path
+    title : str
+    """
+    maes = []
+    for cidx in cosmo_indices:
+        mask = cosmo_labels == cidx
+        if mask.sum() == 0:
+            maes.append(np.nan)
+            continue
+        maes.append(np.mean(np.abs(y_pred[mask] - y_true[mask])))
+
+    fig, ax = plt.subplots(figsize=(max(6, len(cosmo_indices) * 0.3), 4))
+    x_pos = np.arange(len(cosmo_indices))
+    bars = ax.bar(x_pos, maes, color='steelblue', edgecolor='white', linewidth=0.3)
+    ax.set_xticks(x_pos)
+    ax.set_xticklabels([f'c{i:03}' for i in cosmo_indices], rotation=90, fontsize=6)
+    ax.set_xlabel('Cosmology', fontsize=10)
+    ax.set_ylabel(r'MAE ($n_{\rm gal}$)', fontsize=10)
+    if title:
+        ax.set_title(title, fontsize=10)
+    plt.tight_layout()
+    fig.savefig(output_path, bbox_inches='tight', dpi=150)
+    plt.close(fig)
+    print(f'  Saved: {output_path}')
+
+
+def plot_residual_vs_ngal(y_true, y_pred, output_path, title='', n_bins=30):
+    """Binned fractional residual (median ± 1σ band) as a function of n_gal.
+
+    Parameters
+    ----------
+    y_true, y_pred : np.ndarray, shape (N,)
+    output_path : Path
+    title : str
+    n_bins : int
+        Number of bins along the n_gal axis.
+    """
+    frac_res = (y_pred - y_true) / np.abs(y_true) * 100  # percent
+    edges = np.percentile(y_true, np.linspace(0, 100, n_bins + 1))
+    centres, medians, p16, p84 = [], [], [], []
+
+    for lo, hi in zip(edges[:-1], edges[1:]):
+        mask = (y_true >= lo) & (y_true < hi)
+        if mask.sum() < 2:
+            continue
+        centres.append(0.5 * (lo + hi))
+        medians.append(np.median(frac_res[mask]))
+        p16.append(np.percentile(frac_res[mask], 16))
+        p84.append(np.percentile(frac_res[mask], 84))
+
+    centres, medians, p16, p84 = map(np.array, (centres, medians, p16, p84))
+
+    fig, ax = plt.subplots(figsize=(5, 4))
+    ax.axhline(0, color='k', lw=1, ls='--')
+    ax.fill_between(centres, p16, p84, alpha=0.3, color='steelblue', label='16–84th pct')
+    ax.plot(centres, medians, color='steelblue', lw=1.5, label='Median')
+    ax.set_xlabel(r'$n_{\rm gal}$ (truth)', fontsize=11)
+    ax.set_ylabel(r'$\Delta n_{\rm gal} / n_{\rm gal}$ [%]', fontsize=10)
+    ax.legend(fontsize=8)
+    if title:
+        ax.set_title(title, fontsize=10)
+    plt.tight_layout()
+    fig.savefig(output_path, bbox_inches='tight', dpi=150)
+    plt.close(fig)
+    print(f'  Saved: {output_path}')
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def parse_args():
+    """Parse command-line arguments.
+
+    Returns
+    -------
+    argparse.Namespace
+        ``checkpoint`` : str
+            Path to the trained ``.ckpt`` file.
+        ``output_dir`` : str
+            Directory for diagnostic plots and metrics (default: ``./validation``).
+        ``cosmo_idx`` : int or None
+            Restrict validation to a single cosmology index.
+        ``no_plots`` : bool
+            If set, skip figure generation and only print metrics.
+    """
+    parser = argparse.ArgumentParser(
+        description='Validate the n_gal FCN emulator against simulation data.'
+    )
+    parser.add_argument(
+        '--checkpoint',
+        type=str,
+        required=True,
+        help='Path to the trained FCN checkpoint (.ckpt).',
+    )
+    parser.add_argument(
+        '--output-dir',
+        type=str,
+        default='./validation',
+        help='Directory to write diagnostic plots (default: ./validation).',
+    )
+    parser.add_argument(
+        '--cosmo-idx',
+        type=int,
+        default=None,
+        metavar='IDX',
+        help='Restrict validation to a single AbacusSummit cosmology index.',
+    )
+    parser.add_argument(
+        '--no-plots',
+        action='store_true',
+        default=False,
+        help='Skip figure generation; only print metrics to stdout.',
+    )
+    return parser.parse_args()
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    """Run the validation pipeline."""
+    args = parse_args()
+
+    # ------------------------------------------------------------------
+    # Cosmology selection
+    # ------------------------------------------------------------------
+    if args.cosmo_idx is not None:
+        if args.cosmo_idx not in cosmo_list:
+            raise ValueError(
+                f'cosmo_idx {args.cosmo_idx} is not in cosmo_list. '
+                f'Available indices: {cosmo_list}'
+            )
+        cosmo_indices = [args.cosmo_idx]
+        suffix = f'c{args.cosmo_idx:03}'
+    else:
+        cosmo_indices = list(cosmo_list)
+        suffix = 'all'
+
+    # ------------------------------------------------------------------
+    # Load data
+    # ------------------------------------------------------------------
+    print('Loading data...')
+    x, cosmo_labels = get_x(cosmo_indices=cosmo_indices)
+    y_true = get_y(cosmo_indices=cosmo_indices)
+    print(f'  x: {x.shape}  |  y: {y_true.shape}')
+
+    # ------------------------------------------------------------------
+    # Load model and run predictions
+    # ------------------------------------------------------------------
+    print(f'Loading model from {args.checkpoint} ...')
+    model = load_model(args.checkpoint)
+
+    with torch.no_grad():
+        y_pred = model.get_prediction(torch.Tensor(x)).numpy().ravel()
+    print(f'  Predictions range: [{y_pred.min():.4e}, {y_pred.max():.4e}]')
+
+    # ------------------------------------------------------------------
+    # Global metrics
+    # ------------------------------------------------------------------
+    metrics = compute_metrics(y_true, y_pred)
+    print_metrics(metrics, label=f'Global ({suffix})')
+
+    # ------------------------------------------------------------------
+    # Per-cosmology metrics (only when >1 cosmology)
+    # ------------------------------------------------------------------
+    if len(cosmo_indices) > 1:
+        per_cosmo_maes = {}
+        for cidx in cosmo_indices:
+            mask = cosmo_labels == cidx
+            if mask.sum() == 0:
+                continue
+            m = compute_metrics(y_true[mask], y_pred[mask])
+            per_cosmo_maes[cidx] = m['mae']
+
+        worst = max(per_cosmo_maes, key=per_cosmo_maes.get)
+        best  = min(per_cosmo_maes, key=per_cosmo_maes.get)
+        print(f'\n  Best  cosmology: c{best:03}  (MAE = {per_cosmo_maes[best]:.4e})')
+        print(f'  Worst cosmology: c{worst:03}  (MAE = {per_cosmo_maes[worst]:.4e})')
+
+    # ------------------------------------------------------------------
+    # Plots
+    # ------------------------------------------------------------------
+    if args.no_plots:
+        return
+
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    title = f'n_gal emulator — {suffix}'
+
+    print('\nGenerating plots...')
+
+    plot_pred_vs_truth(
+        y_true, y_pred,
+        output_path=out_dir / f'pred_vs_truth_{suffix}.pdf',
+        title=title,
+    )
+    plot_residual_histogram(
+        y_true, y_pred,
+        output_path=out_dir / f'residual_hist_{suffix}.pdf',
+        title=title,
+    )
+    plot_residual_vs_ngal(
+        y_true, y_pred,
+        output_path=out_dir / f'residual_vs_ngal_{suffix}.pdf',
+        title=title,
+    )
+    if len(cosmo_indices) > 1:
+        plot_per_cosmo_mae(
+            y_true, y_pred, cosmo_labels, cosmo_indices,
+            output_path=out_dir / f'per_cosmo_mae_{suffix}.pdf',
+            title=title,
+        )
+
+    print(f'\nAll outputs written to {out_dir}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This pull request introduces support for a number-density (n̄) emulator constraint in the EMC inference pipeline, refactors argument names for clarity, and adds a new script for training the number-density emulator. The changes enhance the flexibility and reproducibility of the inference workflow by allowing users to optionally include a number-density constraint and by improving the consistency of argument naming.

**Support for number-density emulator and argument refactoring:**

* Added support for an optional EMC number-density emulator constraint in both `inference_abacus.py` and `inference_abacus_greedy.py`. This includes loading the emulator checkpoint, passing the model and target density to the sampler, and a new command-line argument (`--use_nbar_emulator`). [[1]](diffhunk://#diff-bd59a0c8136ce61a0539d048fb0b4e72244173e2b17bb12c39ead1432eff9083R40-R44) [[2]](diffhunk://#diff-bd59a0c8136ce61a0539d048fb0b4e72244173e2b17bb12c39ead1432eff9083R204-R209) [[3]](diffhunk://#diff-bd59a0c8136ce61a0539d048fb0b4e72244173e2b17bb12c39ead1432eff9083R221-R222) [[4]](diffhunk://#diff-bd59a0c8136ce61a0539d048fb0b4e72244173e2b17bb12c39ead1432eff9083L242-R269) [[5]](diffhunk://#diff-16c9a3a4c0964dc03de454cda390e65f0a5ef1c0c5cc82afc72b4f3897b697c7R31-R35) [[6]](diffhunk://#diff-16c9a3a4c0964dc03de454cda390e65f0a5ef1c0c5cc82afc72b4f3897b697c7R190-R195) [[7]](diffhunk://#diff-16c9a3a4c0964dc03de454cda390e65f0a5ef1c0c5cc82afc72b4f3897b697c7R207-R208) [[8]](diffhunk://#diff-16c9a3a4c0964dc03de454cda390e65f0a5ef1c0c5cc82afc72b4f3897b697c7L225-R251)

* Refactored argument names related to emulator and covariance options for clarity and consistency (e.g., `--add_cov_emu` → `--use_emulator_covariance`, `--cov_emu_method` → `--emulator_covariance_method`, etc.) and updated their usage throughout the code. [[1]](diffhunk://#diff-bd59a0c8136ce61a0539d048fb0b4e72244173e2b17bb12c39ead1432eff9083L154-R175) [[2]](diffhunk://#diff-bd59a0c8136ce61a0539d048fb0b4e72244173e2b17bb12c39ead1432eff9083L242-R269) [[3]](diffhunk://#diff-16c9a3a4c0964dc03de454cda390e65f0a5ef1c0c5cc82afc72b4f3897b697c7L140-R161) [[4]](diffhunk://#diff-16c9a3a4c0964dc03de454cda390e65f0a5ef1c0c5cc82afc72b4f3897b697c7L225-R251)

**New number-density emulator training script:**

* Added `train_number_density.py`, a new script for training a fully connected network (FCN) emulator that predicts galaxy number density from cosmological and HOD parameters. The script includes data loading, preprocessing, cosmology-level train/val splitting, optional output transforms, and model training with PyTorch Lightning.

**Codebase improvements:**

* Minor import updates to allow access to the new `Observable` class method for loading the number-density model. [[1]](diffhunk://#diff-bd59a0c8136ce61a0539d048fb0b4e72244173e2b17bb12c39ead1432eff9083L6-R6) [[2]](diffhunk://#diff-16c9a3a4c0964dc03de454cda390e65f0a5ef1c0c5cc82afc72b4f3897b697c7L6-R6)

* Added helper functions for loading the number-density emulator model in both inference scripts. [[1]](diffhunk://#diff-bd59a0c8136ce61a0539d048fb0b4e72244173e2b17bb12c39ead1432eff9083R144-R149) [[2]](diffhunk://#diff-16c9a3a4c0964dc03de454cda390e65f0a5ef1c0c5cc82afc72b4f3897b697c7R130-R135)