### PR TITLE
Retire n_test attribute from EMC modules

### DIFF
--- a/acm/observables/bgs/base.py
+++ b/acm/observables/bgs/base.py
@@ -28,9 +28,6 @@ class BaseObservableBGS(Observable):
         if dataset is None and paths is None:
             paths = lookup_registry_path("projects.yaml", "bgs", "Mr-20")
 
-        self.n_test = kwargs.pop(
-            "n_test", 6 * 100
-        )  # FIXME: Remove this on next file compression !
         super().__init__(
             paths=paths,
             flat_output_dims=flat_output_dims,
@@ -59,26 +56,12 @@ class BaseObservableBGS(Observable):
         y_test = getattr(self._dataset, "y_test", None)
 
         if x_test is None or y_test is None:
-            # For backward compatibility
-            if hasattr(self, "n_test"):
-                n_test = self.n_test
-                idx_test = range(n_test) if isinstance(n_test, int) else n_test
-                x_test = self.flatten_output(self._dataset.x, flat_output_dims=2)[
-                    idx_test
-                ]
-                y_test = self.flatten_output(self._dataset.y, flat_output_dims=2)[
-                    idx_test
-                ]
-                logger.warning(
-                    "DEPRECATED: n_test is deprecated. Please provide x_test and y_test in the dataset in the future."
-                )
-            else:
-                raise ValueError(
-                    "x_test and y_test are not available in the dataset. Please provide them or set n_test in the class."
-                )
-        else:
-            x_test = self.drop_nan_dimensions(x_test)
-            y_test = self.drop_nan_dimensions(y_test)
+            raise ValueError(
+                "x_test and y_test are not available in the dataset. Please provide them or set n_test in the class."
+            )
+
+        x_test = self.drop_nan_dimensions(x_test)
+        y_test = self.drop_nan_dimensions(y_test)
 
         # Flatten on 2D for indexing
         # unstack=False because it's either already unstacked or 2D - avoids NaN issues

--- a/acm/observables/emc/base.py
+++ b/acm/observables/emc/base.py
@@ -74,9 +74,9 @@ class BaseObservableEMC(Observable):
             raise ValueError(
                 "x_test and y_test are not available in the dataset. Please provide them in the dataset."
             )
-        else:
-            x_test = self.drop_nan_dimensions(x_test)
-            y_test = self.drop_nan_dimensions(y_test)
+
+        x_test = self.drop_nan_dimensions(x_test)
+        y_test = self.drop_nan_dimensions(y_test)
 
         # Flatten on 2D for indexing
         # unstack=False because it's either already unstacked or 2D - avoids NaN issues

--- a/acm/observables/emc/base.py
+++ b/acm/observables/emc/base.py
@@ -48,9 +48,6 @@ class BaseObservableEMC(Observable):
             except KeyError:
                 pass  # Ignore this step if no checkpoint is found for this stat_name (this will cause the model to not exist, but that's fine)
 
-        self.n_test = kwargs.pop(
-            "n_test", 6 * 500
-        )  # FIXME: Remove this on next file compression ! (backward compatibility)
         super().__init__(paths=paths, flat_output_dims=flat_output_dims, **kwargs)
 
     def get_emulator_covariance_y(
@@ -74,23 +71,9 @@ class BaseObservableEMC(Observable):
         y_test = getattr(self._dataset, "y_test", None)
 
         if x_test is None or y_test is None:
-            # For backward compatibility
-            if hasattr(self, "n_test"):
-                n_test = self.n_test
-                idx_test = range(n_test) if isinstance(n_test, int) else n_test
-                x_test = self.flatten_output(self._dataset.x, flat_output_dims=2)[
-                    idx_test
-                ]
-                y_test = self.flatten_output(self._dataset.y, flat_output_dims=2)[
-                    idx_test
-                ]
-                logger.warning(
-                    "DEPRECATED: n_test is deprecated. Please provide x_test and y_test in the dataset in the future."
-                )
-            else:
-                raise ValueError(
-                    "x_test and y_test are not available in the dataset. Please provide them or set n_test in the class."
-                )
+            raise ValueError(
+                "x_test and y_test are not available in the dataset. Please provide them in the dataset."
+            )
         else:
             x_test = self.drop_nan_dimensions(x_test)
             y_test = self.drop_nan_dimensions(y_test)

--- a/acm/observables/emc/bispectrum_module.py
+++ b/acm/observables/emc/bispectrum_module.py
@@ -22,8 +22,8 @@ class GalaxyBispectrumMultipoles(BaseObservableEMC):
     function multipoles.
     """
 
-    def __init__(self, stat_name="bispectrum", n_test=6 * 500, **kwargs):
-        super().__init__(stat_name=stat_name, n_test=n_test, **kwargs)
+    def __init__(self, stat_name="bispectrum", **kwargs):
+        super().__init__(stat_name=stat_name, **kwargs)
 
     @classmethod
     def compress_covariance(

--- a/acm/observables/emc/dd_knn_module.py
+++ b/acm/observables/emc/dd_knn_module.py
@@ -19,8 +19,8 @@ class DDkNN(BaseObservableEMC):
     Class for the Emulator's Mock Challenge 2D DD-kNN statistic
     """
 
-    def __init__(self, stat_name="dd_knn", n_test=6 * 100, **kwargs):
-        super().__init__(stat_name=stat_name, n_test=n_test, **kwargs)
+    def __init__(self, stat_name="dd_knn", **kwargs):
+        super().__init__(stat_name=stat_name, **kwargs)
 
     def make_mask(self, train_y):
         pass

--- a/acm/observables/emc/density_split_module.py
+++ b/acm/observables/emc/density_split_module.py
@@ -311,9 +311,9 @@ class DensitySplitQuantileGalaxyCorrelationFunctionMultipoles(DensitySplitBaseCl
     """Class for the Emulator's Mock Challenge density-split cross-correlation function multipoles."""
 
     def __init__(
-        self, stat_name: str = "ds_xiqg", n_test: int = 6 * 200, **kwargs
+        self, stat_name: str = "ds_xiqg", **kwargs
     ) -> None:
-        super().__init__(stat_name=stat_name, n_test=n_test, **kwargs)
+        super().__init__(stat_name=stat_name, **kwargs)
 
     @classmethod
     def compress_covariance(cls, **kwargs) -> xarray.Dataset:

--- a/acm/observables/emc/density_split_module.py
+++ b/acm/observables/emc/density_split_module.py
@@ -310,9 +310,7 @@ class DensitySplitBaseClass(BaseObservableEMC):
 class DensitySplitQuantileGalaxyCorrelationFunctionMultipoles(DensitySplitBaseClass):
     """Class for the Emulator's Mock Challenge density-split cross-correlation function multipoles."""
 
-    def __init__(
-        self, stat_name: str = "ds_xiqg", **kwargs
-    ) -> None:
+    def __init__(self, stat_name: str = "ds_xiqg", **kwargs) -> None:
         super().__init__(stat_name=stat_name, **kwargs)
 
     @classmethod

--- a/acm/observables/emc/mst_module.py
+++ b/acm/observables/emc/mst_module.py
@@ -19,8 +19,8 @@ class MinimumSpanningTree(BaseObservableEMC):
     Class for the Emulator's Mock Challenge Minimum Spanning Tree.
     """
 
-    def __init__(self, stat_name="mst", n_test=6 * 500, **kwargs):
-        super().__init__(stat_name=stat_name, n_test=n_test, **kwargs)
+    def __init__(self, stat_name="mst", **kwargs):
+        super().__init__(stat_name=stat_name, **kwargs)
 
     @classmethod
     def compress_covariance(

--- a/acm/observables/emc/projected_tpcf_module.py
+++ b/acm/observables/emc/projected_tpcf_module.py
@@ -22,8 +22,8 @@ class ProjectedGalaxyCorrelationFunction(BaseObservableEMC):
     function multipoles.
     """
 
-    def __init__(self, stat_name="projected_tpcf", n_test=6 * 500, **kwargs):
-        super().__init__(stat_name=stat_name, n_test=n_test, **kwargs)
+    def __init__(self, stat_name="projected_tpcf", **kwargs):
+        super().__init__(stat_name=stat_name, **kwargs)
 
     @classmethod
     def compress_covariance(

--- a/acm/observables/emc/spectrum_module.py
+++ b/acm/observables/emc/spectrum_module.py
@@ -22,8 +22,8 @@ class GalaxyPowerSpectrumMultipoles(BaseObservableEMC):
     function multipoles.
     """
 
-    def __init__(self, stat_name="spectrum", n_test=6 * 250, **kwargs):
-        super().__init__(stat_name=stat_name, n_test=n_test, **kwargs)
+    def __init__(self, stat_name="spectrum", **kwargs):
+        super().__init__(stat_name=stat_name, **kwargs)
 
     @classmethod
     def compress_covariance(

--- a/acm/observables/emc/vide_module.py
+++ b/acm/observables/emc/vide_module.py
@@ -21,8 +21,8 @@ class VIDEVoidGalaxyCorrelationFunctionMultipoles(BaseObservableEMC):
     function multipoles observable.
     """
 
-    def __init__(self, stat_name="vide_ccf", n_test=6 * 100, **kwargs):
-        super().__init__(stat_name=stat_name, n_test=n_test, **kwargs)
+    def __init__(self, stat_name="vide_ccf", **kwargs):
+        super().__init__(stat_name=stat_name, **kwargs)
 
     @classmethod
     def compress_covariance(
@@ -383,8 +383,8 @@ class VIDEVoidSizeFunction(BaseObservableEMC):
     Class for the Emulator's Mock Challenge VIDE void size function observable.
     """
 
-    def __init__(self, stat_name="vide_vsf", n_test=6 * 100, **kwargs):
-        super().__init__(stat_name=stat_name, n_test=n_test, **kwargs)
+    def __init__(self, stat_name="vide_vsf", **kwargs):
+        super().__init__(stat_name=stat_name, **kwargs)
 
     @classmethod
     def compress_covariance(

--- a/acm/observables/emc/wst_module.py
+++ b/acm/observables/emc/wst_module.py
@@ -21,8 +21,8 @@ class WaveletScatteringTransform(BaseObservableEMC):
     function multipoles.
     """
 
-    def __init__(self, stat_name="wst", n_test=6 * 250, **kwargs):
-        super().__init__(stat_name=stat_name, n_test=n_test, **kwargs)
+    def __init__(self, stat_name="wst", **kwargs):
+        super().__init__(stat_name=stat_name, **kwargs)
 
     @staticmethod
     def renorm_wst(inpt, config="J5_L3_q0.8_sigma0.4"):

--- a/scripts/emc/measurements/compress_files.py
+++ b/scripts/emc/measurements/compress_files.py
@@ -49,6 +49,8 @@ LEGACY_TO_ALIAS = {
     "WaveletScatteringTransform": "wst",
 }
 
+TEST_FILTERS = {'cosmo_idx': [0, 1, 2, 3, 4, 13]}
+
 
 def resolve_statistic_name(statistic: str) -> str:
     statistic = LEGACY_TO_ALIAS.get(statistic, statistic)
@@ -75,7 +77,7 @@ parser.add_argument(
     help='Observable alias to compress.',
     default='spectrum',
 )
-parser.add_argument('--n_hod', type=int, default=500, help='Number of HOD realizations to use for compression.')
+parser.add_argument('--n_hod', type=int, default=250, help='Number of HOD realizations to use for compression.')
 parser.add_argument('--add_covariance', action='store_true', help='Whether to add covariance to the compressed data.')
 
 args = parser.parse_args()
@@ -89,4 +91,4 @@ setup_logging()
 paths = lookup_registry_path('projects.yaml', 'emc')
 
 observable = get_class_from_module(module, statistic)
-observable.compress_data(paths=paths, save_to=paths['data_dir'], add_covariance=add_covariance, n_hod=n_hod)
+observable.compress_data(paths=paths, save_to=paths['data_dir'], add_covariance=add_covariance, n_hod=n_hod, test_filters=TEST_FILTERS)

--- a/scripts/emc/training/train_sunbird.py
+++ b/scripts/emc/training/train_sunbird.py
@@ -10,6 +10,9 @@ import argparse
 
 torch.set_float32_matmul_precision('high')
 
+REQUIRED_SPLIT_VARS = ('x_train', 'y_train', 'x_test', 'y_test')
+
+
 def _build_transform(transform_name):
     if transform_name is None:
         return None
@@ -20,17 +23,30 @@ def _build_transform(transform_name):
     raise ValueError(f'Unknown transform: {transform_name}')
 
 
-def TrainFCN(observable, learning_rate, n_hidden, dropout_rate, weight_decay, 
-    model_dir=None, transform_input=None, transform_output=None, val_cosmo_fraction=0.1, seed=None):
+def _require_train_test_split(observable):
+    dataset_vars = set(observable._dataset.data_vars)
+    missing = [name for name in REQUIRED_SPLIT_VARS if name not in dataset_vars]
+    if missing:
+        stat_name = getattr(observable, 'stat_name', 'unknown')
+        missing_str = ', '.join(missing)
+        raise ValueError(
+            f"Compressed EMC dataset for '{stat_name}' is missing {missing_str}. "
+            'This training script requires the train/test split produced during '
+            f"compression. Re-run `scripts/emc/measurements/compress_files.py --statistic {stat_name}` "
+            'for this statistic and try again.'
+        )
+
+
+def TrainFCN(observable, learning_rate, n_hidden, dropout_rate, weight_decay,
+    model_dir=None, transform_input=None, transform_output=None, val_fraction=0.1, seed=None):
 
     np.random.seed(seed)
-    
-    lhc_x = observable.x
-    lhc_y = observable.y
-    print(f'Loaded LHC with shape: {lhc_x.shape}, {lhc_y.shape}')
 
-    ncosmo, nhod = [len(observable.get_coordinate_list(name)) for name in ['cosmo_idx', 'hod_idx']]
-    print(f'Number of cosmologies: {ncosmo}, Number of HODs: {nhod}')
+    _require_train_test_split(observable)
+
+    train_x = observable.x_train
+    train_y = observable.y_train
+    print(f'Loaded training split with shape: {train_x.shape}, {train_y.shape}')
 
     covariance_matrix = observable.get_covariance_matrix(volume_factor=64)
     print(f'Loaded covariance matrix with shape: {covariance_matrix.shape}')
@@ -39,45 +55,28 @@ def TrainFCN(observable, learning_rate, n_hidden, dropout_rate, weight_decay,
     output_transform = _build_transform(transform_output)
 
     if input_transform is not None:
-        lhc_x = input_transform.transform(lhc_x)
+        train_x = input_transform.transform(train_x)
 
     if output_transform is not None:
-        lhc_y = output_transform.transform(lhc_y)
-        
-    ntot = len(lhc_y)
-    n_test_cosmo = 6
-    idx_train = list(range(nhod * n_test_cosmo, ntot))
-    # idx_train = list(range(ntot))
+        train_y = output_transform.transform(train_y)
 
-    print(f'Using {len(idx_train)} samples for training')
+    print(f'Using {len(train_y)} training samples before validation split')
 
-    lhc_train_x = lhc_x[idx_train]
-    lhc_train_y = lhc_y[idx_train]
-
-    cosmo_values = np.array(observable.get_coordinate_list('cosmo_idx'))
-    train_cosmos = cosmo_values[n_test_cosmo:]
-    if len(train_cosmos) < 2:
-        raise ValueError('Need at least 2 training cosmologies to build a cosmology-level validation split.')
-
-    n_val_cosmo = max(1, int(len(train_cosmos) * val_cosmo_fraction))
-    n_val_cosmo = min(n_val_cosmo, len(train_cosmos) - 1)
-    val_cosmos_list = np.random.choice(train_cosmos, size=n_val_cosmo, replace=False)
-    val_cosmos = set(val_cosmos_list)
-
-    cosmo_labels_train = np.repeat(train_cosmos, nhod)
-    val_idx = np.where(np.isin(cosmo_labels_train, list(val_cosmos)))[0].tolist()
-
-    train_mean = np.mean(lhc_train_y, axis=0)
-    train_std = np.std(lhc_train_y, axis=0)
-
-    train_mean_x = np.mean(lhc_train_x, axis=0)
-    train_std_x = np.std(lhc_train_x, axis=0)
-
-    data = ArrayDataModule(x=torch.Tensor(lhc_train_x),
-                        y=torch.Tensor(lhc_train_y), 
-                        val_idx=val_idx, batch_size=128,
-                        num_workers=0)
+    data = ArrayDataModule(
+        x=train_x,
+        y=train_y,
+        val_fraction=val_fraction,
+        batch_size=128,
+        num_workers=0
+    )
     data.setup()
+
+    train_x, train_y = data.ds_train.tensors
+    train_mean = train_y.detach().cpu().numpy().mean(axis=0)
+    train_std = train_y.detach().cpu().numpy().std(axis=0)
+
+    train_mean_x = train_x.detach().cpu().numpy().mean(axis=0)
+    train_std_x = train_x.detach().cpu().numpy().std(axis=0)
 
     model = FCN(
             n_input=data.n_input,
@@ -129,7 +128,7 @@ if __name__ == '__main__':
     parser.add_argument('--transform_output', type=str, choices=['log', 'arcsinh'], default=None, help='Transform to apply to outputs.')
     parser.add_argument('-s', '--statistic', type=str, default='bispectrum', help='Statistic to train on.')
     parser.add_argument('--model_dir', type=str, default=None, help='Directory to save the model.')
-    parser.add_argument('--val_cosmo_fraction', type=float, default=0.1, help='Fraction of training cosmologies to hold out for validation.')
+    parser.add_argument('--val_fraction', type=float, default=0.1, help='Random fraction of training samples to hold out for validation within ArrayDataModule.')
     parser.add_argument('--seed', type=int, default=42, help='Random seed for reproducibility.')
     args = parser.parse_args()
 
@@ -158,6 +157,6 @@ if __name__ == '__main__':
         model_dir=model_dir,
         transform_input=args.transform_input,
         transform_output=args.transform_output,
-        val_cosmo_fraction=args.val_cosmo_fraction,
+        val_fraction=args.val_fraction,
         seed=args.seed,
     )


### PR DESCRIPTION
This pull request removes the deprecated `n_test` argument and all related backward compatibility code from EMC observable classes and their usage, enforcing a stricter requirement that datasets must include explicit train/test splits (`x_train`, `y_train`, `x_test`, `y_test`). The training script is updated to require these splits, and the data handling logic is simplified accordingly. Additionally, the default number of HOD realizations for compression is reduced, and a test filter is added for more controlled data selection during compression.

**Deprecation and removal of `n_test` and backward compatibility:**

- Removed the `n_test` argument from all EMC observable class constructors (e.g., `GalaxyBispectrumMultipoles`, `DDkNN`, `MinimumSpanningTree`, etc.), and eliminated all code that handled the presence or absence of `n_test` for backward compatibility. Now, the code expects datasets to provide explicit train/test splits. [[1]](diffhunk://#diff-24b41ef4d5c3940394b765767596a15b7bf55451ed56ea8a170d0fb5cafd8cc6L51-L53) [[2]](diffhunk://#diff-24b41ef4d5c3940394b765767596a15b7bf55451ed56ea8a170d0fb5cafd8cc6L77-R75) [[3]](diffhunk://#diff-577e03e3c1efa3a6548180a5607f78113658c4d77e8b91670b29f39710239fe0L25-R26) [[4]](diffhunk://#diff-64f216bbcccd2dcd96feb80bf01a5cc197c0b73b0cfed769cc62e69c6f8c5061L22-R23) [[5]](diffhunk://#diff-f2271ff82151a51e15d064f0b150526dfc411c252848cffe5d30fe7736761308L314-R316) [[6]](diffhunk://#diff-541de4d64203c7a48e4c79384ed73317993dde71749ffe37e47060538500ecd3L22-R23) [[7]](diffhunk://#diff-b8f956e38b9f5bc2ce1b5c9b27c556a319c5604f3b9867e619d6ef95d818d806L25-R26) [[8]](diffhunk://#diff-4e03b4415b3943b8d6a311bb5485adb0b32a1e0fcfdd82b5ea0a87f8d4a545c6L25-R26) [[9]](diffhunk://#diff-b089f0e6910a9dbbee7bd4eb19f7bc9143b76767bdc1a3e12820786da0d8417aL24-R25) [[10]](diffhunk://#diff-b089f0e6910a9dbbee7bd4eb19f7bc9143b76767bdc1a3e12820786da0d8417aL386-R387) [[11]](diffhunk://#diff-c9c887610359345bbad71c1689ab5ddb8d5b9b326121df66055783d5b58f0bfcL24-R25)

**Training script improvements and stricter requirements:**

- Updated `scripts/emc/training/train_sunbird.py` to require datasets to have `x_train`, `y_train`, `x_test`, and `y_test` variables, with a validation that raises an error if any are missing. The script now uses only the provided training split and simplifies the validation split logic, relying on a random fraction of samples rather than cosmology-level splits. [[1]](diffhunk://#diff-97048ca1edfec6e5662048d49ee7f597798190dbd5b1447a86b921a6fa4807baR13-R15) [[2]](diffhunk://#diff-97048ca1edfec6e5662048d49ee7f597798190dbd5b1447a86b921a6fa4807baR26-R49) [[3]](diffhunk://#diff-97048ca1edfec6e5662048d49ee7f597798190dbd5b1447a86b921a6fa4807baL42-R79) [[4]](diffhunk://#diff-97048ca1edfec6e5662048d49ee7f597798190dbd5b1447a86b921a6fa4807baL132-R131) [[5]](diffhunk://#diff-97048ca1edfec6e5662048d49ee7f597798190dbd5b1447a86b921a6fa4807baL161-R160)

**Compression script updates:**

- Reduced the default `--n_hod` value from 500 to 250 in `compress_files.py` to match v1.3.
- Added a `TEST_FILTERS` dictionary to filter test samples explicitly during compression, passing this filter to the observable's `compress_data` method. [[1]](diffhunk://#diff-e55f0123adfe6bf7797e9bbf0e244769d54abf80fd5d07f3b8373f0805c01c9fR52-R53) [[2]](diffhunk://#diff-e55f0123adfe6bf7797e9bbf0e244769d54abf80fd5d07f3b8373f0805c01c9fL92-R94)