### PR TITLE
[Feature] Rework compression methods

### DIFF
--- a/acm/utils/compression.py
+++ b/acm/utils/compression.py
@@ -595,6 +595,14 @@ def compress_mocks(
         )
 
     sample_dims = {idx: np.unique(values) for idx, values in index_arrays.items()}
+    n_groups = len(groups)
+    n_expected = np.prod([len(v) for v in sample_dims.values()])
+    if n_groups != n_expected:
+        raise ValueError(
+            f"Index grid is sparse: found {n_groups} groups but expected {n_expected} "
+            f"from unique index combinations {({k: len(v) for k, v in sample_dims.items()})}. "
+            "Ensure all combinations of index values are present in the data."
+        )
 
     coords = cast_coords({**sample_dims, **features_coords})
     data = reshape_to_coords(selected_results, coords)
@@ -618,7 +626,7 @@ def compress_mocks(
 def compress_x(
     root_dir: str | Path,
     index_arrays: dict[str, list],
-) -> xarray.DataArray:
+) -> xarray.DataArray: # pragma: no cover
     """
     Compress "x" data from csv files based on collected index arrays.
 
@@ -687,7 +695,7 @@ def compress_data(
     override_last_dim: bool = True,
     save_fn: str | Path | None = None,
     **kwargs,
-) -> xarray.Dataset:
+) -> xarray.Dataset: # pragma: no cover
     """
     Compress mock measurement data into an xarray Dataset.
 

--- a/acm/utils/compression.py
+++ b/acm/utils/compression.py
@@ -613,6 +613,8 @@ def compress_mocks(
     )
 
     if drop_singleton_dims:
+        singleton_dims = [dim for dim in cout.dims if cout.sizes[dim] == 1]
+        logger.debug(f"Dropping singleton dimensions: {singleton_dims}")
         cout = cout.squeeze(drop=True)
 
     cout.attrs = {

--- a/acm/utils/compression.py
+++ b/acm/utils/compression.py
@@ -1,0 +1,738 @@
+import re
+import time
+import logging
+from typing import Any
+from pathlib import Path
+from collections.abc import Callable
+
+import xarray
+import lsstypes
+import numpy as np
+import pandas as pd
+from pycorr import TwoPointEstimator
+
+from acm.utils.xarray import split_vars, dataset_to_dict
+
+logger = logging.getLogger(__name__)
+
+#%% Readers and filters for different file formats
+def lsstypes_reader(files: list[Path]) -> Any:
+    """
+    Read and average a list of lsstypes files.
+
+    Parameters
+    ----------
+    files : list[Path]
+        List of file paths to read using lsstypes.
+
+    Returns
+    -------
+    Any
+        Averaged lsstypes object across all input files.
+    """
+    loaded = [lsstypes.read(f) for f in files]
+    data = lsstypes.mean(loaded)
+    return data
+
+def lsstypes_filter(
+    data: list[Any], 
+    last_dim: str, 
+    select: dict, 
+    get: dict, 
+    rebin: dict | None = None,
+) -> tuple[np.ndarray, dict]:
+    """
+    Apply selection, optional rebinning, and coordinate extraction to a list of lsstypes objects.
+
+    Filters all elements in ``data`` to match the shape and coordinates of the
+    first element after applying the selection and get operations, then stacks
+    the results into a numpy array.
+
+    Parameters
+    ----------
+    data : list[Any]
+        List of lsstypes objects to filter.
+    last_dim : str
+        Name of the last (feature) dimension, used to extract coordinates
+        from the filtered data and append to the returned dimension dict.
+    select : dict
+        Keyword arguments passed to ``.select()`` to slice the data along
+        one or more dimensions (e.g. ``{'k': (0.01, 0.7)}``).
+    get : dict
+        Keyword arguments passed to ``.get()`` to extract specific entries
+        along one or more dimensions (e.g. ``{'ells': [0, 2]}``).
+    rebin : dict, optional
+        If provided, keyword arguments passed to a first ``.select()`` call
+        before the main selection, used to downsample the data
+        (e.g. ``{'k': slice(0, None, 13)}``).
+
+    Returns
+    -------
+    data_out : np.ndarray
+        Array of shape ``(len(data), ...)`` containing the filtered and
+        matched data for each input object.
+    dims : dict
+        Dictionary mapping dimension names to their coordinate arrays,
+        combining the ``get`` axes and the ``last_dim`` coordinates.
+    """
+    if rebin is not None:
+        d0 = data[0].select(**rebin).select(**select).get(**get)
+    else:
+        d0 = data[0].select(**select).get(**get)
+    
+    ladt_dim_dict = {last_dim: d0.flatten(level=None)[0].coords(last_dim)}
+    dims = {**get, **ladt_dim_dict}
+
+    def lsstypes_match(d):
+        return d.match(d0)
+
+    data_out = np.asarray([lsstypes_match(d) for d in data]) # TODO: use lsstypes.match when available ?
+
+    return data_out, dims
+
+def pycorr_reader(files: list[Path]) -> TwoPointEstimator:
+    """
+    Read and sum a list of pycorr TwoPointEstimator files.
+
+    Parameters
+    ----------
+    files : list[Path]
+        List of file paths to load as TwoPointEstimator objects.
+
+    Returns
+    -------
+    TwoPointEstimator
+        Summed TwoPointEstimator object across all input files.
+    """
+    loaded = [TwoPointEstimator.load(f) for f in files]
+    data = sum(loaded)
+    return data
+
+def pycorr_filter(
+    data: list[TwoPointEstimator],
+    ells: list[int],
+    rebin: int | None = None,
+) -> tuple[np.ndarray, dict]:
+    """
+    Apply optional rebinning and extract specified multipoles from a list of TwoPointEstimator objects.
+
+    For each object in ``data``, selects the specified multipoles with rebinning, 
+    and stacks the results into a numpy array. Also extracts the separation coordinates 
+    from the first object to include in the returned dimension dict.
+
+    Parameters
+    ----------
+    data : list[TwoPointEstimator]
+        List of TwoPointEstimator objects to filter.
+    ells : list[int]
+        List of multipole orders to extract (e.g. ``[0, 2]``).
+    rebin : int, optional
+        If provided, step size for rebinning the data along the separation axis 
+        (e.g. ``3`` to take every 3rd separation bin). 
+        Defaults to ``None`` (no rebinning).
+
+    Returns
+    -------
+    data_out : np.ndarray
+        Array of shape ``(len(data), len(ells), ...)`` containing the extracted multipole data for each input object.
+    dims : dict
+        Dictionary mapping dimension names to their coordinate arrays, including:
+        - ``'ells'``: the list of multipole orders extracted.
+        - ``'s'``: the separation coordinates corresponding to the extracted multipoles, taken from the first object in ``data``.
+    """
+    rebin = rebin or 1
+
+    s, _ = data[0][::rebin](ells=ells, return_sep=True)  # ty:ignore[not-subscriptable]
+
+    data_out = []
+    for d in data:
+        poles = d[::rebin](ells=ells, return_sep=False)  # ty:ignore[not-subscriptable]
+        data_out.append(poles)
+
+    # Stack the results into a numpy array
+    data_out = np.stack(data_out)
+
+    # Create the dimension dictionary
+    dims = {'ells': ells, 's': s}
+
+    return data_out, dims
+
+def ds_reader(files: list[Path]) -> list[TwoPointEstimator]:
+    """
+    Read a list of numpy files containing lists of TwoPointEstimator objects.
+
+    Useful for the densitysplit estimator storage.
+
+    Parameters
+    ----------
+    files : list[Path]
+        List of file paths to load as with numpy, containing a list of TwoPointEstimator objects.
+
+    Returns
+    -------
+    list[TwoPointEstimator]
+        List of loaded TwoPointEstimator objects from the input files.
+    """
+    loaded = [np.load(f, allow_pickle=True) for f in files]
+    data = sum(loaded)
+    return data
+
+def ds_filter(
+    data: list[list[TwoPointEstimator]],
+    quantiles: list[int],
+    ells: list[int],
+    rebin: int | None = None,
+) -> tuple[np.ndarray, dict]:
+    """
+    Apply optional rebinning and extract specified quantiles and multipoles from a list of lists of TwoPointEstimator objects.
+
+    For each object in ``data``, selects the specified quantiles and multipoles with rebinning, 
+    and stacks the results into a numpy array. Also extracts the separation coordinates 
+    from the first object to include in the returned dimension dict.
+
+    Parameters
+    ----------
+    data : list[list[TwoPointEstimator]]
+        List of lists of TwoPointEstimator objects to filter.
+    quantiles : list[int]
+        List of quantile indices to extract.
+    ells : list[int]
+        List of multipole orders to extract (e.g. ``[0, 2]``).
+    rebin : int, optional
+        If provided, step size for rebinning the data along the separation axis 
+        (e.g. ``3`` to take every 3rd separation bin). 
+        Defaults to ``None`` (no rebinning).
+
+    Returns
+    -------
+    data_out : np.ndarray
+        Array of shape ``(len(data), len(ells), ...)`` containing the extracted multipole data for each input object.
+    dims : dict
+        Dictionary mapping dimension names to their coordinate arrays, including:
+        - ``'ells'``: the list of multipole orders extracted.
+        - ``'s'``: the separation coordinates corresponding to the extracted multipoles, taken from the first object in ``data``.
+    """
+    rebin = rebin or 1
+
+    s, _ = data[0][0][::rebin](ells=ells, return_sep=True)  # ty:ignore[not-subscriptable]
+
+    data_out = []
+    for d in data:
+        for q in quantiles:
+            poles = d[q][::rebin](ells=ells, return_sep=False)  # ty:ignore[not-subscriptable]
+            data_out.append(poles)
+
+    # Stack the results into a numpy array
+    data_out = np.stack(data_out)
+
+    # Create the dimension dictionary
+    dims = {'quantiles': quantiles, 'ells': ells, 's': s}
+
+    return data_out, dims
+
+#%% Utility functions for index handling and re-indexing
+def cast_dims(d: dict) -> dict:
+    """
+    Cast dictionary values to float or int where possible, leaving others unchanged.
+
+    Tries float first to preserve precision, then int if the float values are
+    all whole numbers, otherwise keeps the original string values.
+
+    Parameters
+    ----------
+    d : dict
+        Dictionary whose values are to be cast.
+
+    Returns
+    -------
+    dict
+        Dictionary with values cast to int or float where possible.
+    """
+    def cast(arr: np.ndarray) -> np.ndarray:
+        try: 
+            float_arr = np.asarray(arr, dtype=float)
+            if np.all(float_arr == float_arr.astype(int)) and np.issubdtype(float_arr.dtype, np.floating):
+                float_arr = float_arr.astype(int)
+            return float_arr
+        except (ValueError, TypeError):
+            return np.asarray(arr)
+        
+    return {k: cast(v) for k, v in d.items()}
+
+def reindex_samples(
+    index_arrays: dict[str, list],
+    reindex: list[str],
+    group_by: list[str] | None = None,
+) -> dict[str, list]:
+    """
+    Re-index selected index arrays from 0 to n within each sub-group.
+
+    Parameters
+    ----------
+    index_arrays : dict[str, list]
+        Dictionary mapping index names to their raw string values,
+        as collected during file grouping (e.g. ``{'cosmo_idx': ['000', '000', ...], 'hod_idx': ['006', '008', ...]}``)
+    reindex : list[str]
+        Names of indexes to re-index. Defaults to all indexes.
+    group_by : list[str]
+        Index names defining the sub-groups within which re-indexing is
+        performed independently (e.g. ``['cosmo_idx']``).
+        If None, re-indexing is global across all samples.
+
+    Returns
+    -------
+    dict[str, list]
+        Updated index_arrays with re-indexed values as integers for the
+        specified indexes.
+
+    Examples
+    --------
+    >>> index_arrays = {
+    ...     'cosmo_idx': ['000', '000', '000', '001', '001', '001'],
+    ...     'hod_idx':   ['006', '008', '010', '008', '010', '014'],
+    ... }
+    >>> reindex_samples(index_arrays, reindex=['hod_idx'], group_by=['cosmo_idx'])
+    {
+        'cosmo_idx': ['000', '000', '000', '001', '001', '001'],
+        'hod_idx':   [0, 1, 2, 0, 1, 2],
+    }
+    """ 
+    n = len(next(iter(index_arrays.values()))) # Assume all index arrays have the same length
+    result = {k: list(v) for k, v in index_arrays.items()}
+    if group_by is None:
+        group_keys = [()] * n # Single global group
+    else:
+        group_keys = [tuple(index_arrays[g][i] for g in group_by) for i in range(n)]
+
+    for idx_name in reindex:
+        if idx_name not in index_arrays:
+            raise ValueError(f"Index '{idx_name}' not found in index_arrays.")
+
+        vals = index_arrays[idx_name] # Original raw values for this index
+
+        # Build a (group_key, raw_value) -> new_index map in one pass
+        local_maps: dict[tuple, dict] = {} # Map reindexing the values to integers within each group key
+        for gk, raw in zip(group_keys, vals):
+            local_map = local_maps.setdefault(gk, {})
+            local_map.setdefault(raw, len(local_map)) # Assign a new index if this raw value hasn't been seen in this group key
+
+        result[idx_name] = [local_maps[gk][raw] for gk, raw in zip(group_keys, vals)]
+
+    return result
+
+def split_test_set(
+    ds: xarray.Dataset,
+    filters: dict, 
+    to_split: list[str] | None = None,
+    in_name: str = "_test",
+    out_name: str = "_train",
+) -> xarray.Dataset:
+    """
+    Split DataArrays into test/train sets based on filters and merge into a single Dataset.
+    
+    Based on split_vars. "in" matches the filters and is suffixed with in_name, 
+    "out" is the complementary subset suffixed with out_name.
+
+    Parameters
+    ----------
+    ds: xarray.Dataset
+        Input dataset containing the variables to split.
+        Must contain all variables listed in to_split (or defaulting to "x" and "y").
+    filters : dict
+        Dictionary of dimension names and values to filter the DataArrays 
+        (see "in" variables in split_vars).
+    to_split : list[str], optional
+        List of variable names in the dataset to apply the split to. If None,
+        defaults to ``x`` and ``y`` if they exist in the dataset. 
+    in_name : str, default="_test"
+        Suffix for the filtered variable names (the filtered subset).
+    out_name : str, default="_train"
+        Suffix for the complementary variable names (the remaining data after filtering).
+
+    Returns
+    -------
+    xarray.Dataset
+        Split dataset with filtered variables. New data variables have a ``nan_dims`` 
+        attribute listing the dimensions that were filtered out and filled with NaNs 
+        in the complementary variable.
+    """
+    to_split = to_split or ['x', 'y']
+    for v in to_split:
+        if v not in ds:
+            raise ValueError(f"Variable '{v}' not found in dataset. Available variables: {list(ds.data_vars)}")
+
+    logger.debug(f"Splitting variables: {to_split} with filters: {filters}")
+
+    data_vars = [ds[v] for v in to_split]
+    for v_in, v_out in split_vars(*data_vars, **filters):
+        v_in.name = v_in.name + in_name
+        v_out.name = v_out.name + out_name
+
+        # Mark filtered dimensions that will be filled with NaNs
+        v_in.attrs["nan_dims"] = list(filters)  
+        v_out.attrs["nan_dims"] = list(filters)
+
+        ds = xarray.merge([ds, v_in, v_out], join="outer")
+    return ds
+
+#%% Main function to compress mocks into an xarray DataArray
+def collect_mocks(
+    root_dir: str | Path,
+    glob_pattern: str,
+    ignore_index: list[str] | None = None,
+) -> tuple[dict[tuple, list[Path]], dict[str, list]]:
+    """
+    Collect files matching a glob pattern and group them by index combinations.
+
+    Parameters
+    ----------
+    root_dir : str or Path
+        Root directory from which the glob search is performed.
+    glob_pattern : str
+        Glob pattern relative to ``root_dir`` with named index placeholders
+        in curly braces (e.g. ``'c{cosmo_idx}_ph{phase_idx}/hod{hod_idx}/power_spectrum_los_{los}.h5'``).
+        Each ``{name}`` placeholder is extracted as an index dimension unless
+        listed in ``ignore_index``.
+    ignore_index : list[str], optional
+        List of placeholder names to exclude from the output dimensions.
+        Files differing only in these indices are grouped and averaged together.
+        Defaults to ``[]``.
+
+    Returns
+    -------
+    groups : dict[tuple, list[Path]]
+        Dictionary mapping unique index combinations (as tuples of (index_name, value))
+        to lists of file paths that share those index values.
+    index_arrays : dict[str, list]
+        Dictionary mapping tracked index names to lists of their raw string values,
+        collected in the same order as the files are read for later use in coordinate construction.
+    """
+    root_dir = Path(root_dir) # Ensure Path behavior
+    ignore_index = ignore_index or [] # Ensure list behavior
+
+    # Identify indexes from glob pattern
+    indexes = re.findall(r'{(.+?)}', glob_pattern)
+    track_indexes = [idx for idx in indexes if idx not in ignore_index]
+    logger.debug(f"Identified indexes: {indexes}, tracking indexes: {track_indexes}, ignored indexes: {ignore_index}")
+
+    regex_pattern = glob_pattern
+    for idx in indexes:
+        if idx in ignore_index:
+             # Non-capturing group for ignored indexes
+            regex_pattern = regex_pattern.replace(f"{{{idx}}}", r"[^/]+", 1)
+        else:
+            # Named capture group for known indexes
+            regex_pattern = regex_pattern.replace(f"{{{idx}}}", f"(?P<{idx}>[^/]+)", 1)
+    
+    # Replace remaining wildcards (the glob * not from named indexes) with a non-capturing group
+    regex_pattern = regex_pattern.replace("*", r"[^/]+")
+    regex_pattern = re.compile(str(root_dir / regex_pattern))
+
+    logger.debug(f"Constructed regex pattern: {regex_pattern.pattern}")
+
+    # Build glob pattern for file discovery (replace all {idx} with *)
+    flat_glob = glob_pattern
+    for idx in indexes:
+        flat_glob = flat_glob.replace(f"{{{idx}}}", "*")
+
+    files = sorted(root_dir.glob(flat_glob))
+
+    # Group files sharing the same index combination
+    def get_index_key(path) -> tuple | None:
+        m = regex_pattern.match(str(path))
+        if m:
+            return tuple((idx, m.group(idx)) for idx in track_indexes)
+        return None
+    
+    groups = {}
+    for f in files:
+        key = get_index_key(f)
+        if key is not None:
+            groups.setdefault(key, []).append(f)
+
+    index_arrays = {idx: [] for idx in track_indexes}
+    for key in groups:
+        for idx, value in key:
+            index_arrays[idx].append(value)
+
+    logger.debug(f"Found {len(files)} files grouped into {len(groups)} unique index combinations.")
+
+    return groups, index_arrays
+
+def compress_mocks(
+    groups: dict[tuple, list[Path]],
+    index_arrays: dict[str, list],
+    reindex: list[str] | None = None,
+    reindex_group_by: list[str] | None = None,
+    drop_singleton_dims: bool = True,
+    reader: Callable = lsstypes_reader,
+    filter: Callable = lsstypes_filter,
+    **kwargs,
+) -> xarray.DataArray:
+    """
+    Read, average, filter, and package mock measurement files into an xarray DataArray.
+
+    Scans ``root_dir`` for files matching ``glob_pattern``, groups them by the
+    index placeholders defined in the pattern, averages each group using
+    ``reader``, applies ``filter`` to extract features, and assembles the
+    results into a labelled multi-dimensional array.
+
+    Parameters
+    ----------
+    groups : dict[tuple, list[Path]]
+        Dictionary mapping unique index combinations (as tuples of (index_name, value))
+        to lists of file paths that share those index values, as returned by ``collect_mocks``.
+    index_arrays : dict[str, list]
+        Dictionary mapping tracked index names to lists of their raw string values,
+        collected in the same order as the files are read for later use in coordinate construction.
+    reindex : list[str], optional
+        Names of indexes to re-map to contiguous integers starting from 0.
+        Useful when an index (e.g. ``hod_idx``) does not share the same values
+        across all sub-groups. Defaults to ``None`` (no re-indexing).
+    reindex_group_by : list[str], optional
+        Index names defining the sub-groups within which re-indexing is performed
+        independently (e.g. ``['cosmo_idx']``). Must be provided if ``reindex``
+        is set. Defaults to ``None``.
+    drop_singleton_dims : bool, optional
+        If ``True``, squeeze out any dimensions of length 1 from the output
+        DataArray. Defaults to ``True``.
+    reader : callable, optional
+        Function with signature ``(files: list[Path]) -> Any`` used to load
+        and combine a group of files. Defaults to :func:`lsstypes_reader`.
+    filter : callable, optional
+        Function with signature ``(data: list[Any], **kwargs) -> tuple[np.ndarray, dict]``
+        used to select, rebin, and extract coordinates from the loaded data.
+        Defaults to :func:`lsstypes_filter`.
+    **kwargs
+        Additional keyword arguments forwarded to ``filter`` (e.g. ``select``,
+        ``get``, ``rebin``, ``last_dim``).
+
+    Returns
+    -------
+    xarray.DataArray
+        Multi-dimensional labelled array with:
+
+        - **sample dimensions** — one axis per tracked index placeholder
+          (e.g. ``cosmo_idx``, ``hod_idx``), with coordinates set to the
+          unique values found across all matched files.
+        - **feature dimensions** — axes returned by ``filter`` representing
+          the measurement coordinates (e.g. ``ells``, ``k``).
+        - **attrs** — metadata dict with keys ``'sample'`` and ``'features'``
+          listing the corresponding dimension names.
+
+    Notes
+    -----
+    Files are sorted before grouping, ensuring a deterministic ordering of
+    index values in the output coordinates.
+    """
+
+    # Read all files in order
+    t0 = time.time()
+    results = [reader(group_files) for group_files in groups.values()]
+    logger.debug(f"Read {sum(len(v) for v in groups.values())} files in {time.time() - t0:.2f} seconds.")
+
+    selected_results, features_dims = filter(results, **kwargs)
+    logger.debug(f"Filtered data shape: {selected_results.shape}, feature dimensions: {features_dims}")
+
+    if reindex:
+        index_arrays = reindex_samples(index_arrays, reindex=reindex, group_by=reindex_group_by)
+        logger.debug(f"Re-indexed samples for indexes: {reindex} with group_by: {reindex_group_by}")
+    
+    sample_dims = {idx: np.unique(values) for idx, values in index_arrays.items()}
+    
+    dims = cast_dims({**sample_dims, **features_dims})
+    shape = [len(v) for v in dims.values()]
+
+    # TODO: drop singleton dims here instead ? 
+    # Otherwise they still exist in the DataArray, which can be confusing
+
+    cout = xarray.DataArray(
+        data = selected_results.reshape(shape),
+        coords = dims,
+        dims = list(dims),
+        attrs = {
+            'sample': list(sample_dims),
+            'features': list(features_dims),
+        }
+    )
+
+    if drop_singleton_dims:
+        cout = cout.squeeze(drop=True)
+
+    return cout
+
+
+#%% NOTE: Examples compression function (project-dependent, to be moved somewhere else ?)
+def compress_x(
+    root_dir: str | Path,
+    index_arrays: dict[str, list],
+) -> xarray.DataArray:
+    """
+    Compress "x" data from csv files based on collected index arrays.
+
+    Example of a custom compression function to read and stack "x" data from csv files based on the collected index arrays.
+    This is a placeholder implementation and should be adapted to the specific file structure and data format of the "x" data.
+    
+    Parameters
+    ----------
+    root_dir : str or Path
+        Root directory where the csv files are located.
+    index_arrays : dict[str, list]
+        Dictionary mapping index names to lists of their raw string values, as collected during file grouping.
+        Expected to contain keys 'cosmo_idx' and 'hod_idx' corresponding to the file naming convention.
+
+    Returns
+    -------
+    xarray.DataArray
+        DataArray containing the compressed "x" data with appropriate dimensions and coordinates based on the index arrays.
+    """
+    logger.warning("Using a placeholder compress_x function. Please adapt this function to your specific file structure and data format.")
+    root_dir = Path(root_dir)
+    cosmos = np.asarray(index_arrays['cosmo_idx'], dtype=int)
+    hods = np.asarray(index_arrays['hod_idx'], dtype=int)
+
+    x = []  # Placeholder for the compressed data
+    for c in np.unique(cosmos):
+        fn = root_dir / f"AbacusSummit_c{c:03d}.csv"
+        hod_c = hods[cosmos == c]
+
+        x_c = pd.read_csv(fn).iloc[hod_c]
+        x.append(x_c)
+
+    df = pd.concat(x, ignore_index=True)
+    x_names = df.columns.str.replace(r"[ #]", "", regex=True)
+
+    # Create dimensions
+    index_arrays = reindex_samples(index_arrays, reindex=['hod_idx'], group_by=['cosmo_idx'])
+    sample_dims = {idx: np.unique(index_arrays[idx]) for idx in ['cosmo_idx', 'hod_idx']}
+    features_dims = {'parameters': x_names}
+
+    dims = cast_dims({**sample_dims, **features_dims})
+    shape = [len(v) for v in dims.values()]
+
+    cout = xarray.DataArray(
+        data = df.to_numpy().reshape(shape),
+        coords = dims,
+        dims = list(dims),
+        attrs = {
+            'sample': list(sample_dims),
+            'features': list(features_dims),
+        }
+    )
+    return cout
+
+def compress_data(
+    glob_fn: str,
+    paths: dict[str, str],
+    covariance_hod: int = 157,
+    test_filters: dict[str, list] | None = None,
+    override_last_dim: bool = True,
+    save_fn: str | Path | None = None,
+    **kwargs,
+) -> xarray.Dataset:
+    """
+    Compress mock measurement data into an xarray Dataset.
+
+    Parameters
+    ----------
+    glob_fn : str
+        Glob pattern for collecting mock measurement filenames, 
+        relative to the encoded glob pattern.
+    paths : dict[str, str]
+        Dictionary containing paths for measurements and parameters, 
+        with keys "measurements_dir" and "params_dir".
+    covariance_hod : int, optional
+        HOD index to use for the covariance data, if available. 
+        If None, covariance data will not be included in the output dataset.
+        Defaults to 157.
+    test_filters : dict[str, list], optional
+        Dictionary of filters to apply for splitting the test set, 
+        passed to ``split_test_set``. 
+        Defaults to None (no splitting).
+    override_last_dim : bool, default=True
+        If True and covariance data is included, override the coordinates of 
+        the last dimension of the covariance DataArray to match those of 
+        the "y" DataArray, ensuring they are aligned for later use.
+    save_fn : str or Path, optional
+        If provided, path to save the compressed dataset as a numpy file. 
+        The dataset is converted to a dictionary and saved as a numpy array
+        for later loading. Defaults to None (no saving).
+    **kwargs
+        Additional keyword arguments forwarded to ``compress_mocks``.
+
+    Returns
+    -------
+    xarray.Dataset
+        Dataset containing the compressed "x" and "y", and optionally "covariance_y" data, 
+        with appropriate dimensions and coordinates based on the collected index arrays. 
+        If test_filters are provided, the dataset will also 
+        include split test/train variables with "_test" and "_train" suffixes.
+    """
+    logger.warning("Using a placeholder compress_data function. Please adapt this function to your specific file structure, data format, and desired processing steps.")
+    groups, index_arrays = collect_mocks(
+        root_dir = paths["measurements_dir"] + "base",
+        glob_pattern = 'c{cosmo_idx}_ph{phase_idx}/seed{seed}/hod{hod_idx}/' + glob_fn,
+        # ignore_index = ['los'],
+    )
+
+    x = compress_x(
+        root_dir = paths["param_dir"],
+        index_arrays = index_arrays,
+    )
+
+    y = compress_mocks(
+        groups = groups,
+        index_arrays = index_arrays,
+        reindex = ['hod_idx'],
+        reindex_group_by = ['cosmo_idx', 'phase_idx', 'seed'],
+        **kwargs,
+    )
+    logger.info(f"Compressed x and y data with shapes {x.shape} and {y.shape} respectively.")
+    data_vars = {'x': x, 'y': y}
+
+    # Covariance
+    if covariance_hod is not None:
+        groups, index_arrays = collect_mocks(
+            root_dir = paths["measurements_dir"] + "small",
+            glob_pattern = 'c{cosmo_idx}_ph{phase_idx}/seed{seed}/' + f'hod{covariance_hod:03d}/' + glob_fn,
+            # ignore_index = ['los'],
+        )
+        covariance_y = compress_mocks(
+            groups = groups,
+            index_arrays = index_arrays,
+            **kwargs,
+        )
+        if override_last_dim:
+            # Check consistency of last dimensions
+            lcy = covariance_y.coords[covariance_y.dims[-1]]
+            ly = y.coords[y.dims[-1]]
+            if lcy.name != ly.name:
+                logger.warning(f"Inconsistent last dimensions between covariance_y and y: {lcy.name} vs {ly.name}.")
+            if lcy.shape != ly.shape:
+                raise ValueError(
+                    f"Cannot override last dimension of covariance_y due to shape mismatch: {lcy.shape} vs {ly.shape}. "
+                    "Ensure that the coordinates along this dimension are compatible for alignment."
+                ) 
+            covariance_y = covariance_y.assign_coords({lcy.name: ly})
+            logger.debug(
+                f"Overriding last dimension of covariance_y with y coordinates along {ly.name}."
+            )
+        else:
+            logger.warning(
+                "Not overriding last dimension of covariance_y. Ensure that the coordinates are aligned with y to avoid nan values."
+            )
+        logger.info(f"Compressed covariance_y data with shape {covariance_y.shape}.")
+        data_vars['covariance_y'] = covariance_y
+
+    cout = xarray.Dataset(data_vars = data_vars)
+
+    if test_filters is not None:
+        cout = split_test_set(cout, test_filters)
+    
+    if save_fn is not None:
+        Path(save_fn).parent.mkdir(parents=True, exist_ok=True)
+        payload = np.array(dataset_to_dict(cout), dtype=object)
+        np.save(save_fn, payload)
+        logger.info(f"Saved compressed dataset to {save_fn}.")
+
+    return cout

--- a/acm/utils/compression.py
+++ b/acm/utils/compression.py
@@ -594,17 +594,17 @@ def compress_mocks(
             f"Re-indexed samples for indexes: {reindex} with group_by: {reindex_group_by}"
         )
 
-    sample_dims = {idx: np.unique(values) for idx, values in index_arrays.items()}
+    sample_coords = {idx: np.unique(values) for idx, values in index_arrays.items()}
     n_groups = len(groups)
-    n_expected = np.prod([len(v) for v in sample_dims.values()])
+    n_expected = np.prod([len(v) for v in sample_coords.values()])
     if n_groups != n_expected:
         raise ValueError(
             f"Index grid is sparse: found {n_groups} groups but expected {n_expected} "
-            f"from unique index combinations { ({k: len(v) for k, v in sample_dims.items()}) }. "
+            f"from unique index combinations { ({k: len(v) for k, v in sample_coords.items()}) }. "
             "Ensure all combinations of index values are present in the data."
         )
 
-    coords = cast_coords({**sample_dims, **features_coords})
+    coords = cast_coords({**sample_coords, **features_coords})
     data = reshape_to_coords(selected_results, coords)
 
     cout = xarray.DataArray(
@@ -618,8 +618,8 @@ def compress_mocks(
         cout = cout.squeeze(drop=True)
 
     cout.attrs = {
-        "sample": [s for s in sample_dims if s in cout.dims],
-        "features": [s for s in sample_dims if s in cout.dims],
+        "sample": [s for s in sample_coords if s in cout.dims],
+        "features": [s for s in features_coords if s in cout.dims],
     }  # Assign attrs here to avoid singleton dimension in attrs
 
     return cout

--- a/acm/utils/compression.py
+++ b/acm/utils/compression.py
@@ -1,21 +1,22 @@
+import logging
 import re
 import time
-import logging
-from typing import Any
-from pathlib import Path
 from collections.abc import Callable
+from pathlib import Path
+from typing import Any
 
-import xarray
 import lsstypes
 import numpy as np
 import pandas as pd
+import xarray
 from pycorr import TwoPointEstimator
 
-from acm.utils.xarray import split_vars, dataset_to_dict
+from acm.utils.xarray import dataset_to_dict, split_vars
 
 logger = logging.getLogger(__name__)
 
-#%% Readers and filters for different file formats
+
+# %% Readers and filters for different file formats
 def lsstypes_reader(files: list[Path]) -> Any:
     """
     Read and average a list of lsstypes files.
@@ -34,11 +35,12 @@ def lsstypes_reader(files: list[Path]) -> Any:
     data = lsstypes.mean(loaded)
     return data
 
+
 def lsstypes_filter(
-    data: list[Any], 
-    last_dim: str, 
-    select: dict, 
-    get: dict, 
+    data: list[Any],
+    last_dim: str,
+    select: dict,
+    get: dict,
     rebin: dict | None = None,
 ) -> tuple[np.ndarray, dict]:
     """
@@ -79,16 +81,19 @@ def lsstypes_filter(
         d0 = data[0].select(**rebin).select(**select).get(**get)
     else:
         d0 = data[0].select(**select).get(**get)
-    
+
     ladt_dim_dict = {last_dim: d0.flatten(level=None)[0].coords(last_dim)}
     dims = {**get, **ladt_dim_dict}
 
     def lsstypes_match(d):
         return d.match(d0)
 
-    data_out = np.asarray([lsstypes_match(d) for d in data]) # TODO: use lsstypes.match when available ?
+    data_out = np.asarray(
+        [lsstypes_match(d) for d in data]
+    )  # TODO: use lsstypes.match when available ?
 
     return data_out, dims
+
 
 def pycorr_reader(files: list[Path]) -> TwoPointEstimator:
     """
@@ -108,6 +113,7 @@ def pycorr_reader(files: list[Path]) -> TwoPointEstimator:
     data = sum(loaded)
     return data
 
+
 def pycorr_filter(
     data: list[TwoPointEstimator],
     ells: list[int],
@@ -116,8 +122,8 @@ def pycorr_filter(
     """
     Apply optional rebinning and extract specified multipoles from a list of TwoPointEstimator objects.
 
-    For each object in ``data``, selects the specified multipoles with rebinning, 
-    and stacks the results into a numpy array. Also extracts the separation coordinates 
+    For each object in ``data``, selects the specified multipoles with rebinning,
+    and stacks the results into a numpy array. Also extracts the separation coordinates
     from the first object to include in the returned dimension dict.
 
     Parameters
@@ -127,8 +133,8 @@ def pycorr_filter(
     ells : list[int]
         List of multipole orders to extract (e.g. ``[0, 2]``).
     rebin : int, optional
-        If provided, step size for rebinning the data along the separation axis 
-        (e.g. ``3`` to take every 3rd separation bin). 
+        If provided, step size for rebinning the data along the separation axis
+        (e.g. ``3`` to take every 3rd separation bin).
         Defaults to ``None`` (no rebinning).
 
     Returns
@@ -153,9 +159,10 @@ def pycorr_filter(
     data_out = np.stack(data_out)
 
     # Create the dimension dictionary
-    dims = {'ells': ells, 's': s}
+    dims = {"ells": ells, "s": s}
 
     return data_out, dims
+
 
 def ds_reader(files: list[Path]) -> list[TwoPointEstimator]:
     """
@@ -177,6 +184,7 @@ def ds_reader(files: list[Path]) -> list[TwoPointEstimator]:
     data = sum(loaded)
     return data
 
+
 def ds_filter(
     data: list[list[TwoPointEstimator]],
     quantiles: list[int],
@@ -186,8 +194,8 @@ def ds_filter(
     """
     Apply optional rebinning and extract specified quantiles and multipoles from a list of lists of TwoPointEstimator objects.
 
-    For each object in ``data``, selects the specified quantiles and multipoles with rebinning, 
-    and stacks the results into a numpy array. Also extracts the separation coordinates 
+    For each object in ``data``, selects the specified quantiles and multipoles with rebinning,
+    and stacks the results into a numpy array. Also extracts the separation coordinates
     from the first object to include in the returned dimension dict.
 
     Parameters
@@ -199,8 +207,8 @@ def ds_filter(
     ells : list[int]
         List of multipole orders to extract (e.g. ``[0, 2]``).
     rebin : int, optional
-        If provided, step size for rebinning the data along the separation axis 
-        (e.g. ``3`` to take every 3rd separation bin). 
+        If provided, step size for rebinning the data along the separation axis
+        (e.g. ``3`` to take every 3rd separation bin).
         Defaults to ``None`` (no rebinning).
 
     Returns
@@ -226,11 +234,12 @@ def ds_filter(
     data_out = np.stack(data_out)
 
     # Create the dimension dictionary
-    dims = {'quantiles': quantiles, 'ells': ells, 's': s}
+    dims = {"quantiles": quantiles, "ells": ells, "s": s}
 
     return data_out, dims
 
-#%% Utility functions for index handling and re-indexing
+
+# %% Utility functions for index handling and re-indexing
 def cast_dims(d: dict) -> dict:
     """
     Cast dictionary values to float or int where possible, leaving others unchanged.
@@ -248,16 +257,20 @@ def cast_dims(d: dict) -> dict:
     dict
         Dictionary with values cast to int or float where possible.
     """
+
     def cast(arr: np.ndarray) -> np.ndarray:
-        try: 
+        try:
             float_arr = np.asarray(arr, dtype=float)
-            if np.all(float_arr == float_arr.astype(int)) and np.issubdtype(float_arr.dtype, np.floating):
+            if np.all(float_arr == float_arr.astype(int)) and np.issubdtype(
+                float_arr.dtype, np.floating
+            ):
                 float_arr = float_arr.astype(int)
             return float_arr
         except (ValueError, TypeError):
             return np.asarray(arr)
-        
+
     return {k: cast(v) for k, v in d.items()}
+
 
 def reindex_samples(
     index_arrays: dict[str, list],
@@ -296,11 +309,13 @@ def reindex_samples(
         'cosmo_idx': ['000', '000', '000', '001', '001', '001'],
         'hod_idx':   [0, 1, 2, 0, 1, 2],
     }
-    """ 
-    n = len(next(iter(index_arrays.values()))) # Assume all index arrays have the same length
+    """
+    n = len(
+        next(iter(index_arrays.values()))
+    )  # Assume all index arrays have the same length
     result = {k: list(v) for k, v in index_arrays.items()}
     if group_by is None:
-        group_keys = [()] * n # Single global group
+        group_keys = [()] * n  # Single global group
     else:
         group_keys = [tuple(index_arrays[g][i] for g in group_by) for i in range(n)]
 
@@ -308,29 +323,34 @@ def reindex_samples(
         if idx_name not in index_arrays:
             raise ValueError(f"Index '{idx_name}' not found in index_arrays.")
 
-        vals = index_arrays[idx_name] # Original raw values for this index
+        vals = index_arrays[idx_name]  # Original raw values for this index
 
         # Build a (group_key, raw_value) -> new_index map in one pass
-        local_maps: dict[tuple, dict] = {} # Map reindexing the values to integers within each group key
+        local_maps: dict[
+            tuple, dict
+        ] = {}  # Map reindexing the values to integers within each group key
         for gk, raw in zip(group_keys, vals):
             local_map = local_maps.setdefault(gk, {})
-            local_map.setdefault(raw, len(local_map)) # Assign a new index if this raw value hasn't been seen in this group key
+            local_map.setdefault(
+                raw, len(local_map)
+            )  # Assign a new index if this raw value hasn't been seen in this group key
 
         result[idx_name] = [local_maps[gk][raw] for gk, raw in zip(group_keys, vals)]
 
     return result
 
+
 def split_test_set(
     ds: xarray.Dataset,
-    filters: dict, 
+    filters: dict,
     to_split: list[str] | None = None,
     in_name: str = "_test",
     out_name: str = "_train",
 ) -> xarray.Dataset:
     """
     Split DataArrays into test/train sets based on filters and merge into a single Dataset.
-    
-    Based on split_vars. "in" matches the filters and is suffixed with in_name, 
+
+    Based on split_vars. "in" matches the filters and is suffixed with in_name,
     "out" is the complementary subset suffixed with out_name.
 
     Parameters
@@ -339,11 +359,11 @@ def split_test_set(
         Input dataset containing the variables to split.
         Must contain all variables listed in to_split (or defaulting to "x" and "y").
     filters : dict
-        Dictionary of dimension names and values to filter the DataArrays 
+        Dictionary of dimension names and values to filter the DataArrays
         (see "in" variables in split_vars).
     to_split : list[str], optional
         List of variable names in the dataset to apply the split to. If None,
-        defaults to ``x`` and ``y`` if they exist in the dataset. 
+        defaults to ``x`` and ``y`` if they exist in the dataset.
     in_name : str, default="_test"
         Suffix for the filtered variable names (the filtered subset).
     out_name : str, default="_train"
@@ -352,14 +372,16 @@ def split_test_set(
     Returns
     -------
     xarray.Dataset
-        Split dataset with filtered variables. New data variables have a ``nan_dims`` 
-        attribute listing the dimensions that were filtered out and filled with NaNs 
+        Split dataset with filtered variables. New data variables have a ``nan_dims``
+        attribute listing the dimensions that were filtered out and filled with NaNs
         in the complementary variable.
     """
-    to_split = to_split or ['x', 'y']
+    to_split = to_split or ["x", "y"]
     for v in to_split:
         if v not in ds:
-            raise ValueError(f"Variable '{v}' not found in dataset. Available variables: {list(ds.data_vars)}")
+            raise ValueError(
+                f"Variable '{v}' not found in dataset. Available variables: {list(ds.data_vars)}"
+            )
 
     logger.debug(f"Splitting variables: {to_split} with filters: {filters}")
 
@@ -369,13 +391,14 @@ def split_test_set(
         v_out.name = v_out.name + out_name
 
         # Mark filtered dimensions that will be filled with NaNs
-        v_in.attrs["nan_dims"] = list(filters)  
+        v_in.attrs["nan_dims"] = list(filters)
         v_out.attrs["nan_dims"] = list(filters)
 
         ds = xarray.merge([ds, v_in, v_out], join="outer")
     return ds
 
-#%% Main function to compress mocks into an xarray DataArray
+
+# %% Main function to compress mocks into an xarray DataArray
 def collect_mocks(
     root_dir: str | Path,
     glob_pattern: str,
@@ -407,23 +430,25 @@ def collect_mocks(
         Dictionary mapping tracked index names to lists of their raw string values,
         collected in the same order as the files are read for later use in coordinate construction.
     """
-    root_dir = Path(root_dir) # Ensure Path behavior
-    ignore_index = ignore_index or [] # Ensure list behavior
+    root_dir = Path(root_dir)  # Ensure Path behavior
+    ignore_index = ignore_index or []  # Ensure list behavior
 
     # Identify indexes from glob pattern
-    indexes = re.findall(r'{(.+?)}', glob_pattern)
+    indexes = re.findall(r"{(.+?)}", glob_pattern)
     track_indexes = [idx for idx in indexes if idx not in ignore_index]
-    logger.debug(f"Identified indexes: {indexes}, tracking indexes: {track_indexes}, ignored indexes: {ignore_index}")
+    logger.debug(
+        f"Identified indexes: {indexes}, tracking indexes: {track_indexes}, ignored indexes: {ignore_index}"
+    )
 
     regex_pattern = glob_pattern
     for idx in indexes:
         if idx in ignore_index:
-             # Non-capturing group for ignored indexes
+            # Non-capturing group for ignored indexes
             regex_pattern = regex_pattern.replace(f"{{{idx}}}", r"[^/]+", 1)
         else:
             # Named capture group for known indexes
             regex_pattern = regex_pattern.replace(f"{{{idx}}}", f"(?P<{idx}>[^/]+)", 1)
-    
+
     # Replace remaining wildcards (the glob * not from named indexes) with a non-capturing group
     regex_pattern = regex_pattern.replace("*", r"[^/]+")
     regex_pattern = re.compile(str(root_dir / regex_pattern))
@@ -443,7 +468,7 @@ def collect_mocks(
         if m:
             return tuple((idx, m.group(idx)) for idx in track_indexes)
         return None
-    
+
     groups = {}
     for f in files:
         key = get_index_key(f)
@@ -455,9 +480,12 @@ def collect_mocks(
         for idx, value in key:
             index_arrays[idx].append(value)
 
-    logger.debug(f"Found {len(files)} files grouped into {len(groups)} unique index combinations.")
+    logger.debug(
+        f"Found {len(files)} files grouped into {len(groups)} unique index combinations."
+    )
 
     return groups, index_arrays
+
 
 def compress_mocks(
     groups: dict[tuple, list[Path]],
@@ -529,31 +557,39 @@ def compress_mocks(
     # Read all files in order
     t0 = time.time()
     results = [reader(group_files) for group_files in groups.values()]
-    logger.debug(f"Read {sum(len(v) for v in groups.values())} files in {time.time() - t0:.2f} seconds.")
+    logger.debug(
+        f"Read {sum(len(v) for v in groups.values())} files in {time.time() - t0:.2f} seconds."
+    )
 
     selected_results, features_dims = filter(results, **kwargs)
-    logger.debug(f"Filtered data shape: {selected_results.shape}, feature dimensions: {features_dims}")
+    logger.debug(
+        f"Filtered data shape: {selected_results.shape}, feature dimensions: {features_dims}"
+    )
 
     if reindex:
-        index_arrays = reindex_samples(index_arrays, reindex=reindex, group_by=reindex_group_by)
-        logger.debug(f"Re-indexed samples for indexes: {reindex} with group_by: {reindex_group_by}")
-    
+        index_arrays = reindex_samples(
+            index_arrays, reindex=reindex, group_by=reindex_group_by
+        )
+        logger.debug(
+            f"Re-indexed samples for indexes: {reindex} with group_by: {reindex_group_by}"
+        )
+
     sample_dims = {idx: np.unique(values) for idx, values in index_arrays.items()}
-    
+
     dims = cast_dims({**sample_dims, **features_dims})
     shape = [len(v) for v in dims.values()]
 
-    # TODO: drop singleton dims here instead ? 
+    # TODO: drop singleton dims here instead ?
     # Otherwise they still exist in the DataArray, which can be confusing
 
     cout = xarray.DataArray(
-        data = selected_results.reshape(shape),
-        coords = dims,
-        dims = list(dims),
-        attrs = {
-            'sample': list(sample_dims),
-            'features': list(features_dims),
-        }
+        data=selected_results.reshape(shape),
+        coords=dims,
+        dims=list(dims),
+        attrs={
+            "sample": list(sample_dims),
+            "features": list(features_dims),
+        },
     )
 
     if drop_singleton_dims:
@@ -562,7 +598,7 @@ def compress_mocks(
     return cout
 
 
-#%% NOTE: Examples compression function (project-dependent, to be moved somewhere else ?)
+# %% NOTE: Examples compression function (project-dependent, to be moved somewhere else ?)
 def compress_x(
     root_dir: str | Path,
     index_arrays: dict[str, list],
@@ -572,7 +608,7 @@ def compress_x(
 
     Example of a custom compression function to read and stack "x" data from csv files based on the collected index arrays.
     This is a placeholder implementation and should be adapted to the specific file structure and data format of the "x" data.
-    
+
     Parameters
     ----------
     root_dir : str or Path
@@ -586,10 +622,12 @@ def compress_x(
     xarray.DataArray
         DataArray containing the compressed "x" data with appropriate dimensions and coordinates based on the index arrays.
     """
-    logger.warning("Using a placeholder compress_x function. Please adapt this function to your specific file structure and data format.")
+    logger.warning(
+        "Using a placeholder compress_x function. Please adapt this function to your specific file structure and data format."
+    )
     root_dir = Path(root_dir)
-    cosmos = np.asarray(index_arrays['cosmo_idx'], dtype=int)
-    hods = np.asarray(index_arrays['hod_idx'], dtype=int)
+    cosmos = np.asarray(index_arrays["cosmo_idx"], dtype=int)
+    hods = np.asarray(index_arrays["hod_idx"], dtype=int)
 
     x = []  # Placeholder for the compressed data
     for c in np.unique(cosmos):
@@ -603,23 +641,28 @@ def compress_x(
     x_names = df.columns.str.replace(r"[ #]", "", regex=True)
 
     # Create dimensions
-    index_arrays = reindex_samples(index_arrays, reindex=['hod_idx'], group_by=['cosmo_idx'])
-    sample_dims = {idx: np.unique(index_arrays[idx]) for idx in ['cosmo_idx', 'hod_idx']}
-    features_dims = {'parameters': x_names}
+    index_arrays = reindex_samples(
+        index_arrays, reindex=["hod_idx"], group_by=["cosmo_idx"]
+    )
+    sample_dims = {
+        idx: np.unique(index_arrays[idx]) for idx in ["cosmo_idx", "hod_idx"]
+    }
+    features_dims = {"parameters": x_names}
 
     dims = cast_dims({**sample_dims, **features_dims})
     shape = [len(v) for v in dims.values()]
 
     cout = xarray.DataArray(
-        data = df.to_numpy().reshape(shape),
-        coords = dims,
-        dims = list(dims),
-        attrs = {
-            'sample': list(sample_dims),
-            'features': list(features_dims),
-        }
+        data=df.to_numpy().reshape(shape),
+        coords=dims,
+        dims=list(dims),
+        attrs={
+            "sample": list(sample_dims),
+            "features": list(features_dims),
+        },
     )
     return cout
+
 
 def compress_data(
     glob_fn: str,
@@ -636,25 +679,25 @@ def compress_data(
     Parameters
     ----------
     glob_fn : str
-        Glob pattern for collecting mock measurement filenames, 
+        Glob pattern for collecting mock measurement filenames,
         relative to the encoded glob pattern.
     paths : dict[str, str]
-        Dictionary containing paths for measurements and parameters, 
+        Dictionary containing paths for measurements and parameters,
         with keys "measurements_dir" and "params_dir".
     covariance_hod : int, optional
-        HOD index to use for the covariance data, if available. 
+        HOD index to use for the covariance data, if available.
         If None, covariance data will not be included in the output dataset.
         Defaults to 157.
     test_filters : dict[str, list], optional
-        Dictionary of filters to apply for splitting the test set, 
-        passed to ``split_test_set``. 
+        Dictionary of filters to apply for splitting the test set,
+        passed to ``split_test_set``.
         Defaults to None (no splitting).
     override_last_dim : bool, default=True
-        If True and covariance data is included, override the coordinates of 
-        the last dimension of the covariance DataArray to match those of 
+        If True and covariance data is included, override the coordinates of
+        the last dimension of the covariance DataArray to match those of
         the "y" DataArray, ensuring they are aligned for later use.
     save_fn : str or Path, optional
-        If provided, path to save the compressed dataset as a numpy file. 
+        If provided, path to save the compressed dataset as a numpy file.
         The dataset is converted to a dictionary and saved as a numpy array
         for later loading. Defaults to None (no saving).
     **kwargs
@@ -663,43 +706,49 @@ def compress_data(
     Returns
     -------
     xarray.Dataset
-        Dataset containing the compressed "x" and "y", and optionally "covariance_y" data, 
-        with appropriate dimensions and coordinates based on the collected index arrays. 
-        If test_filters are provided, the dataset will also 
+        Dataset containing the compressed "x" and "y", and optionally "covariance_y" data,
+        with appropriate dimensions and coordinates based on the collected index arrays.
+        If test_filters are provided, the dataset will also
         include split test/train variables with "_test" and "_train" suffixes.
     """
-    logger.warning("Using a placeholder compress_data function. Please adapt this function to your specific file structure, data format, and desired processing steps.")
+    logger.warning(
+        "Using a placeholder compress_data function. Please adapt this function to your specific file structure, data format, and desired processing steps."
+    )
     groups, index_arrays = collect_mocks(
-        root_dir = paths["measurements_dir"] + "base",
-        glob_pattern = 'c{cosmo_idx}_ph{phase_idx}/seed{seed}/hod{hod_idx}/' + glob_fn,
+        root_dir=paths["measurements_dir"] + "base",
+        glob_pattern="c{cosmo_idx}_ph{phase_idx}/seed{seed}/hod{hod_idx}/" + glob_fn,
         # ignore_index = ['los'],
     )
 
     x = compress_x(
-        root_dir = paths["param_dir"],
-        index_arrays = index_arrays,
+        root_dir=paths["param_dir"],
+        index_arrays=index_arrays,
     )
 
     y = compress_mocks(
-        groups = groups,
-        index_arrays = index_arrays,
-        reindex = ['hod_idx'],
-        reindex_group_by = ['cosmo_idx', 'phase_idx', 'seed'],
+        groups=groups,
+        index_arrays=index_arrays,
+        reindex=["hod_idx"],
+        reindex_group_by=["cosmo_idx", "phase_idx", "seed"],
         **kwargs,
     )
-    logger.info(f"Compressed x and y data with shapes {x.shape} and {y.shape} respectively.")
-    data_vars = {'x': x, 'y': y}
+    logger.info(
+        f"Compressed x and y data with shapes {x.shape} and {y.shape} respectively."
+    )
+    data_vars = {"x": x, "y": y}
 
     # Covariance
     if covariance_hod is not None:
         groups, index_arrays = collect_mocks(
-            root_dir = paths["measurements_dir"] + "small",
-            glob_pattern = 'c{cosmo_idx}_ph{phase_idx}/seed{seed}/' + f'hod{covariance_hod:03d}/' + glob_fn,
+            root_dir=paths["measurements_dir"] + "small",
+            glob_pattern="c{cosmo_idx}_ph{phase_idx}/seed{seed}/"
+            + f"hod{covariance_hod:03d}/"
+            + glob_fn,
             # ignore_index = ['los'],
         )
         covariance_y = compress_mocks(
-            groups = groups,
-            index_arrays = index_arrays,
+            groups=groups,
+            index_arrays=index_arrays,
             **kwargs,
         )
         if override_last_dim:
@@ -707,12 +756,14 @@ def compress_data(
             lcy = covariance_y.coords[covariance_y.dims[-1]]
             ly = y.coords[y.dims[-1]]
             if lcy.name != ly.name:
-                logger.warning(f"Inconsistent last dimensions between covariance_y and y: {lcy.name} vs {ly.name}.")
+                logger.warning(
+                    f"Inconsistent last dimensions between covariance_y and y: {lcy.name} vs {ly.name}."
+                )
             if lcy.shape != ly.shape:
                 raise ValueError(
                     f"Cannot override last dimension of covariance_y due to shape mismatch: {lcy.shape} vs {ly.shape}. "
                     "Ensure that the coordinates along this dimension are compatible for alignment."
-                ) 
+                )
             covariance_y = covariance_y.assign_coords({lcy.name: ly})
             logger.debug(
                 f"Overriding last dimension of covariance_y with y coordinates along {ly.name}."
@@ -722,13 +773,13 @@ def compress_data(
                 "Not overriding last dimension of covariance_y. Ensure that the coordinates are aligned with y to avoid nan values."
             )
         logger.info(f"Compressed covariance_y data with shape {covariance_y.shape}.")
-        data_vars['covariance_y'] = covariance_y
+        data_vars["covariance_y"] = covariance_y
 
-    cout = xarray.Dataset(data_vars = data_vars)
+    cout = xarray.Dataset(data_vars=data_vars)
 
     if test_filters is not None:
         cout = split_test_set(cout, test_filters)
-    
+
     if save_fn is not None:
         Path(save_fn).parent.mkdir(parents=True, exist_ok=True)
         payload = np.array(dataset_to_dict(cout), dtype=object)

--- a/acm/utils/compression.py
+++ b/acm/utils/compression.py
@@ -610,14 +610,15 @@ def compress_mocks(
     cout = xarray.DataArray(
         data=data,
         coords=coords,
-        attrs={
-            "sample": list(sample_dims),
-            "features": list(features_coords),
-        },
     )
 
     if drop_singleton_dims:
         cout = cout.squeeze(drop=True)
+    
+    cout.attrs = {
+        "sample": [s for s in sample_dims if s in cout.dims],
+        "features": [s for s in sample_dims if s in cout.dims],
+    } # Assign attrs here to avoid singleton dimension in attrs
 
     return cout
 

--- a/acm/utils/compression.py
+++ b/acm/utils/compression.py
@@ -92,7 +92,7 @@ def lsstypes_postprocess(
         [lsstypes_match(d) for d in data]
     )  # TODO: use lsstypes.match when available ?
 
-    tmp_coords = {'data': np.arange(len(data)), **coords}
+    tmp_coords = {"data": np.arange(len(data)), **coords}
     data_out = reshape_to_coords(data_out, tmp_coords)
 
     return data_out, coords
@@ -160,7 +160,7 @@ def pycorr_postprocess(
         data_out.append(poles)
     data_out = np.stack(data_out)
 
-    tmp_coords = {'data': np.arange(len(data)), **coords}
+    tmp_coords = {"data": np.arange(len(data)), **coords}
     data_out = reshape_to_coords(data_out, tmp_coords)
 
     return data_out, coords
@@ -234,7 +234,7 @@ def ds_postprocess(
             data_out.append(poles)
     data_out = np.stack(data_out)
 
-    tmp_coords = {'data': np.arange(len(data)), **coords}
+    tmp_coords = {"data": np.arange(len(data)), **coords}
     data_out = reshape_to_coords(data_out, tmp_coords)
 
     return data_out, coords
@@ -263,6 +263,7 @@ def reshape_to_coords(arr: np.ndarray, coords: dict) -> np.ndarray:
             f"Cannot reshape array of size {arr.size} to shape {shape} based on provided coordinates."
         )
     return arr.reshape(shape)
+
 
 def cast_coords(d: dict) -> dict:
     """
@@ -458,7 +459,9 @@ def collect_mocks(
         f"Identified indexes: {indexes}, tracking indexes: {track_indexes}, ignored indexes: {ignore_index}"
     )
 
-    regex_pattern = re.escape(str(root_dir / glob_pattern))  # Escape special characters for regex
+    regex_pattern = re.escape(
+        str(root_dir / glob_pattern)
+    )  # Escape special characters for regex
     for idx in indexes:
         placeholder = re.escape(f"{{{idx}}}")
         if idx in ignore_index:
@@ -727,7 +730,7 @@ def compress_data(
         "Using a placeholder compress_data function. Please adapt this function to your specific file structure, data format, and desired processing steps."
     )
     groups, index_arrays = collect_mocks(
-        root_dir = Path(paths["measurements_dir"]) / "base",
+        root_dir=Path(paths["measurements_dir"]) / "base",
         glob_pattern="c{cosmo_idx}_ph{phase_idx}/seed{seed}/hod{hod_idx}/" + glob_fn,
         # ignore_index = ['los'],
     )
@@ -752,7 +755,7 @@ def compress_data(
     # Covariance
     if covariance_hod is not None:
         groups, index_arrays = collect_mocks(
-            root_dir = Path(paths["measurements_dir"]) / "small",
+            root_dir=Path(paths["measurements_dir"]) / "small",
             glob_pattern="c{cosmo_idx}_ph{phase_idx}/seed{seed}/"
             + f"hod{covariance_hod:03d}/"
             + glob_fn,

--- a/acm/utils/compression.py
+++ b/acm/utils/compression.py
@@ -614,11 +614,11 @@ def compress_mocks(
 
     if drop_singleton_dims:
         cout = cout.squeeze(drop=True)
-    
+
     cout.attrs = {
         "sample": [s for s in sample_dims if s in cout.dims],
         "features": [s for s in sample_dims if s in cout.dims],
-    } # Assign attrs here to avoid singleton dimension in attrs
+    }  # Assign attrs here to avoid singleton dimension in attrs
 
     return cout
 

--- a/acm/utils/compression.py
+++ b/acm/utils/compression.py
@@ -16,7 +16,7 @@ from acm.utils.xarray import dataset_to_dict, split_vars
 logger = logging.getLogger(__name__)
 
 
-# %% Readers and filters for different file formats
+# %% Readers and processors for different file formats
 def lsstypes_reader(files: list[Path]) -> Any:
     """
     Read and average a list of lsstypes files.
@@ -36,7 +36,7 @@ def lsstypes_reader(files: list[Path]) -> Any:
     return data
 
 
-def lsstypes_filter(
+def lsstypes_postprocess(
     data: list[Any],
     last_dim: str,
     select: dict,
@@ -53,10 +53,10 @@ def lsstypes_filter(
     Parameters
     ----------
     data : list[Any]
-        List of lsstypes objects to filter.
+        List of lsstypes objects to process.
     last_dim : str
         Name of the last (feature) dimension, used to extract coordinates
-        from the filtered data and append to the returned dimension dict.
+        from the processed data and append to the returned dimension dict.
     select : dict
         Keyword arguments passed to ``.select()`` to slice the data along
         one or more dimensions (e.g. ``{'k': (0.01, 0.7)}``).
@@ -71,9 +71,9 @@ def lsstypes_filter(
     Returns
     -------
     data_out : np.ndarray
-        Array of shape ``(len(data), ...)`` containing the filtered and
+        Array of shape ``(len(data), ...)`` containing the processed and
         matched data for each input object.
-    dims : dict
+    coords : dict
         Dictionary mapping dimension names to their coordinate arrays,
         combining the ``get`` axes and the ``last_dim`` coordinates.
     """
@@ -82,8 +82,8 @@ def lsstypes_filter(
     else:
         d0 = data[0].select(**select).get(**get)
 
-    ladt_dim_dict = {last_dim: d0.flatten(level=None)[0].coords(last_dim)}
-    dims = {**get, **ladt_dim_dict}
+    last_dim_dict = {last_dim: d0.flatten(level=None)[0].coords(last_dim)}
+    coords = {**get, **last_dim_dict}
 
     def lsstypes_match(d):
         return d.match(d0)
@@ -92,7 +92,10 @@ def lsstypes_filter(
         [lsstypes_match(d) for d in data]
     )  # TODO: use lsstypes.match when available ?
 
-    return data_out, dims
+    tmp_coords = {'data': np.arange(len(data)), **coords}
+    data_out = reshape_to_coords(data_out, tmp_coords)
+
+    return data_out, coords
 
 
 def pycorr_reader(files: list[Path]) -> TwoPointEstimator:
@@ -114,7 +117,7 @@ def pycorr_reader(files: list[Path]) -> TwoPointEstimator:
     return data
 
 
-def pycorr_filter(
+def pycorr_postprocess(
     data: list[TwoPointEstimator],
     ells: list[int],
     rebin: int | None = None,
@@ -124,12 +127,12 @@ def pycorr_filter(
 
     For each object in ``data``, selects the specified multipoles with rebinning,
     and stacks the results into a numpy array. Also extracts the separation coordinates
-    from the first object to include in the returned dimension dict.
+    from the first object to include in the returned coordinates dict.
 
     Parameters
     ----------
     data : list[TwoPointEstimator]
-        List of TwoPointEstimator objects to filter.
+        List of TwoPointEstimator objects to process.
     ells : list[int]
         List of multipole orders to extract (e.g. ``[0, 2]``).
     rebin : int, optional
@@ -141,7 +144,7 @@ def pycorr_filter(
     -------
     data_out : np.ndarray
         Array of shape ``(len(data), len(ells), ...)`` containing the extracted multipole data for each input object.
-    dims : dict
+    coords : dict
         Dictionary mapping dimension names to their coordinate arrays, including:
         - ``'ells'``: the list of multipole orders extracted.
         - ``'s'``: the separation coordinates corresponding to the extracted multipoles, taken from the first object in ``data``.
@@ -149,19 +152,18 @@ def pycorr_filter(
     rebin = rebin or 1
 
     s, _ = data[0][::rebin](ells=ells, return_sep=True)  # ty:ignore[not-subscriptable]
+    coords = {"ells": ells, "s": s}
 
     data_out = []
     for d in data:
         poles = d[::rebin](ells=ells, return_sep=False)  # ty:ignore[not-subscriptable]
         data_out.append(poles)
-
-    # Stack the results into a numpy array
     data_out = np.stack(data_out)
 
-    # Create the dimension dictionary
-    dims = {"ells": ells, "s": s}
+    tmp_coords = {'data': np.arange(len(data)), **coords}
+    data_out = reshape_to_coords(data_out, tmp_coords)
 
-    return data_out, dims
+    return data_out, coords
 
 
 def ds_reader(files: list[Path]) -> list[TwoPointEstimator]:
@@ -182,10 +184,10 @@ def ds_reader(files: list[Path]) -> list[TwoPointEstimator]:
     """
     loaded = [np.load(f, allow_pickle=True) for f in files]
     data = sum(loaded)
-    return data
+    return data.tolist()
 
 
-def ds_filter(
+def ds_postprocess(
     data: list[list[TwoPointEstimator]],
     quantiles: list[int],
     ells: list[int],
@@ -196,12 +198,12 @@ def ds_filter(
 
     For each object in ``data``, selects the specified quantiles and multipoles with rebinning,
     and stacks the results into a numpy array. Also extracts the separation coordinates
-    from the first object to include in the returned dimension dict.
+    from the first object to include in the returned coordinates dict.
 
     Parameters
     ----------
     data : list[list[TwoPointEstimator]]
-        List of lists of TwoPointEstimator objects to filter.
+        List of lists of TwoPointEstimator objects to process.
     quantiles : list[int]
         List of quantile indices to extract.
     ells : list[int]
@@ -215,7 +217,7 @@ def ds_filter(
     -------
     data_out : np.ndarray
         Array of shape ``(len(data), len(ells), ...)`` containing the extracted multipole data for each input object.
-    dims : dict
+    coords : dict
         Dictionary mapping dimension names to their coordinate arrays, including:
         - ``'ells'``: the list of multipole orders extracted.
         - ``'s'``: the separation coordinates corresponding to the extracted multipoles, taken from the first object in ``data``.
@@ -223,24 +225,46 @@ def ds_filter(
     rebin = rebin or 1
 
     s, _ = data[0][0][::rebin](ells=ells, return_sep=True)  # ty:ignore[not-subscriptable]
+    coords = {"quantiles": quantiles, "ells": ells, "s": s}
 
     data_out = []
     for d in data:
         for q in quantiles:
             poles = d[q][::rebin](ells=ells, return_sep=False)  # ty:ignore[not-subscriptable]
             data_out.append(poles)
-
-    # Stack the results into a numpy array
     data_out = np.stack(data_out)
 
-    # Create the dimension dictionary
-    dims = {"quantiles": quantiles, "ells": ells, "s": s}
+    tmp_coords = {'data': np.arange(len(data)), **coords}
+    data_out = reshape_to_coords(data_out, tmp_coords)
 
-    return data_out, dims
+    return data_out, coords
 
 
 # %% Utility functions for index handling and re-indexing
-def cast_dims(d: dict) -> dict:
+def reshape_to_coords(arr: np.ndarray, coords: dict) -> np.ndarray:
+    """
+    Reshape an array to match the lengths of the provided dimension coordinate.
+
+    Parameters
+    ----------
+    arr : np.ndarray
+        Array to reshape.
+    coords : dict
+        Dictionary mapping dimension names to their coordinate, used to determine the target shape.
+
+    Returns
+    -------
+    np.ndarray
+        Reshaped array with shape matching the lengths of the coordinates.
+    """
+    shape = [len(v) for v in coords.values()]
+    if arr.size != np.prod(shape):
+        raise ValueError(
+            f"Cannot reshape array of size {arr.size} to shape {shape} based on provided coordinates."
+        )
+    return arr.reshape(shape)
+
+def cast_coords(d: dict) -> dict:
     """
     Cast dictionary values to float or int where possible, leaving others unchanged.
 
@@ -344,14 +368,12 @@ def split_test_set(
     ds: xarray.Dataset,
     filters: dict,
     to_split: list[str] | None = None,
-    in_name: str = "_test",
-    out_name: str = "_train",
 ) -> xarray.Dataset:
     """
     Split DataArrays into test/train sets based on filters and merge into a single Dataset.
 
-    Based on split_vars. "in" matches the filters and is suffixed with in_name,
-    "out" is the complementary subset suffixed with out_name.
+    Based on split_vars. "in" matches the filters and is suffixed with "_test",
+    "out" is the complementary subset suffixed with "_train".
 
     Parameters
     ----------
@@ -364,10 +386,6 @@ def split_test_set(
     to_split : list[str], optional
         List of variable names in the dataset to apply the split to. If None,
         defaults to ``x`` and ``y`` if they exist in the dataset.
-    in_name : str, default="_test"
-        Suffix for the filtered variable names (the filtered subset).
-    out_name : str, default="_train"
-        Suffix for the complementary variable names (the remaining data after filtering).
 
     Returns
     -------
@@ -387,8 +405,8 @@ def split_test_set(
 
     data_vars = [ds[v] for v in to_split]
     for v_in, v_out in split_vars(*data_vars, **filters):
-        v_in.name = v_in.name + in_name
-        v_out.name = v_out.name + out_name
+        v_in.name = v_in.name + "_test"
+        v_out.name = v_out.name + "_train"
 
         # Mark filtered dimensions that will be filled with NaNs
         v_in.attrs["nan_dims"] = list(filters)
@@ -440,18 +458,19 @@ def collect_mocks(
         f"Identified indexes: {indexes}, tracking indexes: {track_indexes}, ignored indexes: {ignore_index}"
     )
 
-    regex_pattern = glob_pattern
+    regex_pattern = re.escape(str(root_dir / glob_pattern))  # Escape special characters for regex
     for idx in indexes:
+        placeholder = re.escape(f"{{{idx}}}")
         if idx in ignore_index:
             # Non-capturing group for ignored indexes
-            regex_pattern = regex_pattern.replace(f"{{{idx}}}", r"[^/]+", 1)
+            regex_pattern = regex_pattern.replace(placeholder, r"[^/]+", 1)
         else:
             # Named capture group for known indexes
-            regex_pattern = regex_pattern.replace(f"{{{idx}}}", f"(?P<{idx}>[^/]+)", 1)
+            regex_pattern = regex_pattern.replace(placeholder, f"(?P<{idx}>[^/]+)", 1)
 
     # Replace remaining wildcards (the glob * not from named indexes) with a non-capturing group
-    regex_pattern = regex_pattern.replace("*", r"[^/]+")
-    regex_pattern = re.compile(str(root_dir / regex_pattern))
+    regex_pattern = regex_pattern.replace(r"\*", r"[^/]+")
+    regex_pattern = re.compile(regex_pattern)
 
     logger.debug(f"Constructed regex pattern: {regex_pattern.pattern}")
 
@@ -494,16 +513,14 @@ def compress_mocks(
     reindex_group_by: list[str] | None = None,
     drop_singleton_dims: bool = True,
     reader: Callable = lsstypes_reader,
-    filter: Callable = lsstypes_filter,
+    postprocess: Callable = lsstypes_postprocess,
     **kwargs,
 ) -> xarray.DataArray:
     """
-    Read, average, filter, and package mock measurement files into an xarray DataArray.
+    Average, processes, and package mock measurement files into an xarray DataArray.
 
-    Scans ``root_dir`` for files matching ``glob_pattern``, groups them by the
-    index placeholders defined in the pattern, averages each group using
-    ``reader``, applies ``filter`` to extract features, and assembles the
-    results into a labelled multi-dimensional array.
+    Averages each file group using ``reader``, applies ``postprocess`` to extract features
+    and coordinates, and assembles the results into a labelled multi-dimensional array.
 
     Parameters
     ----------
@@ -527,12 +544,12 @@ def compress_mocks(
     reader : callable, optional
         Function with signature ``(files: list[Path]) -> Any`` used to load
         and combine a group of files. Defaults to :func:`lsstypes_reader`.
-    filter : callable, optional
+    postprocess : callable, optional
         Function with signature ``(data: list[Any], **kwargs) -> tuple[np.ndarray, dict]``
         used to select, rebin, and extract coordinates from the loaded data.
-        Defaults to :func:`lsstypes_filter`.
+        Defaults to :func:`lsstypes_postprocess`.
     **kwargs
-        Additional keyword arguments forwarded to ``filter`` (e.g. ``select``,
+        Additional keyword arguments forwarded to ``postprocess`` (e.g. ``select``,
         ``get``, ``rebin``, ``last_dim``).
 
     Returns
@@ -543,7 +560,7 @@ def compress_mocks(
         - **sample dimensions** — one axis per tracked index placeholder
           (e.g. ``cosmo_idx``, ``hod_idx``), with coordinates set to the
           unique values found across all matched files.
-        - **feature dimensions** — axes returned by ``filter`` representing
+        - **feature dimensions** — axes returned by ``postprocess`` representing
           the measurement coordinates (e.g. ``ells``, ``k``).
         - **attrs** — metadata dict with keys ``'sample'`` and ``'features'``
           listing the corresponding dimension names.
@@ -561,9 +578,9 @@ def compress_mocks(
         f"Read {sum(len(v) for v in groups.values())} files in {time.time() - t0:.2f} seconds."
     )
 
-    selected_results, features_dims = filter(results, **kwargs)
+    selected_results, features_coords = postprocess(results, **kwargs)
     logger.debug(
-        f"Filtered data shape: {selected_results.shape}, feature dimensions: {features_dims}"
+        f"Processed data shape: {selected_results.shape}, feature coordinates: {features_coords}"
     )
 
     if reindex:
@@ -576,19 +593,15 @@ def compress_mocks(
 
     sample_dims = {idx: np.unique(values) for idx, values in index_arrays.items()}
 
-    dims = cast_dims({**sample_dims, **features_dims})
-    shape = [len(v) for v in dims.values()]
-
-    # TODO: drop singleton dims here instead ?
-    # Otherwise they still exist in the DataArray, which can be confusing
+    coords = cast_coords({**sample_dims, **features_coords})
+    data = reshape_to_coords(selected_results, coords)
 
     cout = xarray.DataArray(
-        data=selected_results.reshape(shape),
-        coords=dims,
-        dims=list(dims),
+        data=data,
+        coords=coords,
         attrs={
             "sample": list(sample_dims),
-            "features": list(features_dims),
+            "features": list(features_coords),
         },
     )
 
@@ -640,25 +653,24 @@ def compress_x(
     df = pd.concat(x, ignore_index=True)
     x_names = df.columns.str.replace(r"[ #]", "", regex=True)
 
-    # Create dimensions
+    # Create coordinates
     index_arrays = reindex_samples(
         index_arrays, reindex=["hod_idx"], group_by=["cosmo_idx"]
     )
-    sample_dims = {
+    sample_coords = {
         idx: np.unique(index_arrays[idx]) for idx in ["cosmo_idx", "hod_idx"]
     }
-    features_dims = {"parameters": x_names}
+    features_coords = {"parameters": x_names}
 
-    dims = cast_dims({**sample_dims, **features_dims})
-    shape = [len(v) for v in dims.values()]
+    coords = cast_coords({**sample_coords, **features_coords})
+    data = reshape_to_coords(df.to_numpy(), coords)
 
     cout = xarray.DataArray(
-        data=df.to_numpy().reshape(shape),
-        coords=dims,
-        dims=list(dims),
+        data=data,
+        coords=coords,
         attrs={
-            "sample": list(sample_dims),
-            "features": list(features_dims),
+            "sample": list(sample_coords),
+            "features": list(features_coords),
         },
     )
     return cout
@@ -683,7 +695,7 @@ def compress_data(
         relative to the encoded glob pattern.
     paths : dict[str, str]
         Dictionary containing paths for measurements and parameters,
-        with keys "measurements_dir" and "params_dir".
+        with keys "measurements_dir" and "param_dir".
     covariance_hod : int, optional
         HOD index to use for the covariance data, if available.
         If None, covariance data will not be included in the output dataset.
@@ -715,7 +727,7 @@ def compress_data(
         "Using a placeholder compress_data function. Please adapt this function to your specific file structure, data format, and desired processing steps."
     )
     groups, index_arrays = collect_mocks(
-        root_dir=paths["measurements_dir"] + "base",
+        root_dir = Path(paths["measurements_dir"]) / "base",
         glob_pattern="c{cosmo_idx}_ph{phase_idx}/seed{seed}/hod{hod_idx}/" + glob_fn,
         # ignore_index = ['los'],
     )
@@ -740,7 +752,7 @@ def compress_data(
     # Covariance
     if covariance_hod is not None:
         groups, index_arrays = collect_mocks(
-            root_dir=paths["measurements_dir"] + "small",
+            root_dir = Path(paths["measurements_dir"]) / "small",
             glob_pattern="c{cosmo_idx}_ph{phase_idx}/seed{seed}/"
             + f"hod{covariance_hod:03d}/"
             + glob_fn,

--- a/acm/utils/compression.py
+++ b/acm/utils/compression.py
@@ -600,7 +600,7 @@ def compress_mocks(
     if n_groups != n_expected:
         raise ValueError(
             f"Index grid is sparse: found {n_groups} groups but expected {n_expected} "
-            f"from unique index combinations {({k: len(v) for k, v in sample_dims.items()})}. "
+            f"from unique index combinations { ({k: len(v) for k, v in sample_dims.items()}) }. "
             "Ensure all combinations of index values are present in the data."
         )
 
@@ -626,7 +626,7 @@ def compress_mocks(
 def compress_x(
     root_dir: str | Path,
     index_arrays: dict[str, list],
-) -> xarray.DataArray: # pragma: no cover
+) -> xarray.DataArray:  # pragma: no cover
     """
     Compress "x" data from csv files based on collected index arrays.
 
@@ -695,7 +695,7 @@ def compress_data(
     override_last_dim: bool = True,
     save_fn: str | Path | None = None,
     **kwargs,
-) -> xarray.Dataset: # pragma: no cover
+) -> xarray.Dataset:  # pragma: no cover
     """
     Compress mock measurement data into an xarray Dataset.
 

--- a/acm/utils/compression.py
+++ b/acm/utils/compression.py
@@ -37,7 +37,7 @@ def lsstypes_reader(files: list[Path]) -> object:
 
 
 def lsstypes_postprocess(
-    data: list[Any],
+    data: list[object],
     last_dim: str,
     select: dict,
     get: dict,
@@ -52,7 +52,7 @@ def lsstypes_postprocess(
 
     Parameters
     ----------
-    data : list[Any]
+    data : list[object]
         List of lsstypes objects to process.
     last_dim : str
         Name of the last (feature) dimension, used to extract coordinates
@@ -85,7 +85,7 @@ def lsstypes_postprocess(
     last_dim_dict = {last_dim: d0.flatten(level=None)[0].coords(last_dim)}
     coords = {**get, **last_dim_dict}
 
-    def lsstypes_match(d) -> object:
+    def lsstypes_match(d: object) -> object:
         return d.match(d0)
 
     data_out = np.asarray(

--- a/acm/utils/compression.py
+++ b/acm/utils/compression.py
@@ -417,8 +417,8 @@ def split_test_set(
     return ds
 
 
-# %% Main function to compress mocks into an xarray DataArray
-def collect_mocks(
+# %% Main function to compress measurements into an xarray DataArray
+def collect_measurements(
     root_dir: str | Path,
     glob_pattern: str,
     ignore_index: list[str] | None = None,
@@ -509,7 +509,7 @@ def collect_mocks(
     return groups, index_arrays
 
 
-def compress_mocks(
+def compress_measurements(
     groups: dict[tuple, list[Path]],
     index_arrays: dict[str, list],
     reindex: list[str] | None = None,
@@ -520,7 +520,7 @@ def compress_mocks(
     **kwargs,
 ) -> xarray.DataArray:
     """
-    Average, processes, and package mock measurement files into an xarray DataArray.
+    Average, processes, and package measurement files into an xarray DataArray.
 
     Averages each file group using ``reader``, applies ``postprocess`` to extract features
     and coordinates, and assembles the results into a labelled multi-dimensional array.
@@ -529,7 +529,7 @@ def compress_mocks(
     ----------
     groups : dict[tuple, list[Path]]
         Dictionary mapping unique index combinations (as tuples of (index_name, value))
-        to lists of file paths that share those index values, as returned by ``collect_mocks``.
+        to lists of file paths that share those index values, as returned by ``collect_measurements``.
     index_arrays : dict[str, list]
         Dictionary mapping tracked index names to lists of their raw string values,
         collected in the same order as the files are read for later use in coordinate construction.
@@ -700,12 +700,12 @@ def compress_data(
     **kwargs,
 ) -> xarray.Dataset:  # pragma: no cover
     """
-    Compress mock measurement data into an xarray Dataset.
+    Compress measurement data into an xarray Dataset.
 
     Parameters
     ----------
     glob_fn : str
-        Glob pattern for collecting mock measurement filenames,
+        Glob pattern for collecting measurement filenames,
         relative to the encoded glob pattern.
     paths : dict[str, str]
         Dictionary containing paths for measurements and parameters,
@@ -727,7 +727,7 @@ def compress_data(
         The dataset is converted to a dictionary and saved as a numpy array
         for later loading. Defaults to None (no saving).
     **kwargs
-        Additional keyword arguments forwarded to ``compress_mocks``.
+        Additional keyword arguments forwarded to ``compress_measurements``.
 
     Returns
     -------
@@ -740,7 +740,7 @@ def compress_data(
     logger.warning(
         "Using a placeholder compress_data function. Please adapt this function to your specific file structure, data format, and desired processing steps."
     )
-    groups, index_arrays = collect_mocks(
+    groups, index_arrays = collect_measurements(
         root_dir=Path(paths["measurements_dir"]) / "base",
         glob_pattern="c{cosmo_idx}_ph{phase_idx}/seed{seed}/hod{hod_idx}/" + glob_fn,
         # ignore_index = ['los'],
@@ -751,7 +751,7 @@ def compress_data(
         index_arrays=index_arrays,
     )
 
-    y = compress_mocks(
+    y = compress_measurements(
         groups=groups,
         index_arrays=index_arrays,
         reindex=["hod_idx"],
@@ -765,14 +765,14 @@ def compress_data(
 
     # Covariance
     if covariance_hod is not None:
-        groups, index_arrays = collect_mocks(
+        groups, index_arrays = collect_measurements(
             root_dir=Path(paths["measurements_dir"]) / "small",
             glob_pattern="c{cosmo_idx}_ph{phase_idx}/seed{seed}/"
             + f"hod{covariance_hod:03d}/"
             + glob_fn,
             # ignore_index = ['los'],
         )
-        covariance_y = compress_mocks(
+        covariance_y = compress_measurements(
             groups=groups,
             index_arrays=index_arrays,
             **kwargs,

--- a/acm/utils/compression.py
+++ b/acm/utils/compression.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 
 type LsstypeObject = lsstypes.ObservableLeaf | lsstypes.ObservableTree
 
+
 # %% Readers and processors for different file formats
 def lsstypes_reader(files: list[Path]) -> LsstypeObject:
     """

--- a/acm/utils/compression.py
+++ b/acm/utils/compression.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 # %% Readers and processors for different file formats
-def lsstypes_reader(files: list[Path]) -> Any:
+def lsstypes_reader(files: list[Path]) -> object:
     """
     Read and average a list of lsstypes files.
 
@@ -28,7 +28,7 @@ def lsstypes_reader(files: list[Path]) -> Any:
 
     Returns
     -------
-    Any
+    object
         Averaged lsstypes object across all input files.
     """
     loaded = [lsstypes.read(f) for f in files]
@@ -85,7 +85,7 @@ def lsstypes_postprocess(
     last_dim_dict = {last_dim: d0.flatten(level=None)[0].coords(last_dim)}
     coords = {**get, **last_dim_dict}
 
-    def lsstypes_match(d):
+    def lsstypes_match(d) -> object:
         return d.match(d0)
 
     data_out = np.asarray(
@@ -290,9 +290,10 @@ def cast_coords(d: dict) -> dict:
                 float_arr.dtype, np.floating
             ):
                 float_arr = float_arr.astype(int)
-            return float_arr
         except (ValueError, TypeError):
             return np.asarray(arr)
+        else:
+            return float_arr
 
     return {k: cast(v) for k, v in d.items()}
 
@@ -354,13 +355,13 @@ def reindex_samples(
         local_maps: dict[
             tuple, dict
         ] = {}  # Map reindexing the values to integers within each group key
-        for gk, raw in zip(group_keys, vals):
+        for gk, raw in zip(group_keys, vals, strict=False):
             local_map = local_maps.setdefault(gk, {})
             local_map.setdefault(
                 raw, len(local_map)
             )  # Assign a new index if this raw value hasn't been seen in this group key
 
-        result[idx_name] = [local_maps[gk][raw] for gk, raw in zip(group_keys, vals)]
+        result[idx_name] = [local_maps[gk][raw] for gk, raw in zip(group_keys, vals, strict=False)]
 
     return result
 
@@ -485,7 +486,7 @@ def collect_measurements(
     files = sorted(root_dir.glob(flat_glob))
 
     # Group files sharing the same index combination
-    def get_index_key(path) -> tuple | None:
+    def get_index_key(path: Path | str) -> tuple | None:
         m = regex_pattern.match(str(path))
         if m:
             return tuple((idx, m.group(idx)) for idx in track_indexes)

--- a/acm/utils/compression.py
+++ b/acm/utils/compression.py
@@ -3,7 +3,6 @@ import re
 import time
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
 
 import lsstypes
 import numpy as np
@@ -361,7 +360,9 @@ def reindex_samples(
                 raw, len(local_map)
             )  # Assign a new index if this raw value hasn't been seen in this group key
 
-        result[idx_name] = [local_maps[gk][raw] for gk, raw in zip(group_keys, vals, strict=False)]
+        result[idx_name] = [
+            local_maps[gk][raw] for gk, raw in zip(group_keys, vals, strict=False)
+        ]
 
     return result
 
@@ -574,7 +575,6 @@ def compress_measurements(
     Files are sorted before grouping, ensuring a deterministic ordering of
     index values in the output coordinates.
     """
-
     # Read all files in order
     t0 = time.time()
     results = [reader(group_files) for group_files in groups.values()]
@@ -769,8 +769,7 @@ def compress_data(
         groups, index_arrays = collect_measurements(
             root_dir=Path(paths["measurements_dir"]) / "small",
             glob_pattern="c{cosmo_idx}_ph{phase_idx}/seed{seed}/"
-            + f"hod{covariance_hod:03d}/"
-            + glob_fn,
+            f"hod{covariance_hod:03d}/" + glob_fn,
             # ignore_index = ['los'],
         )
         covariance_y = compress_measurements(

--- a/acm/utils/compression.py
+++ b/acm/utils/compression.py
@@ -14,9 +14,10 @@ from acm.utils.xarray import dataset_to_dict, split_vars
 
 logger = logging.getLogger(__name__)
 
+type LsstypeObject = lsstypes.ObservableLeaf | lsstypes.ObservableTree
 
 # %% Readers and processors for different file formats
-def lsstypes_reader(files: list[Path]) -> object:
+def lsstypes_reader(files: list[Path]) -> LsstypeObject:
     """
     Read and average a list of lsstypes files.
 
@@ -27,7 +28,7 @@ def lsstypes_reader(files: list[Path]) -> object:
 
     Returns
     -------
-    object
+    lsstypes.ObservableLeaf | lsstypes.ObservableTree
         Averaged lsstypes object across all input files.
     """
     loaded = [lsstypes.read(f) for f in files]
@@ -36,7 +37,7 @@ def lsstypes_reader(files: list[Path]) -> object:
 
 
 def lsstypes_postprocess(
-    data: list[object],
+    data: list["lsstypes.ObservableLeaf | lsstypes.ObservableTree"],
     last_dim: str,
     select: dict,
     get: dict,
@@ -51,7 +52,7 @@ def lsstypes_postprocess(
 
     Parameters
     ----------
-    data : list[object]
+    data : list[lsstypes.ObservableLeaf | lsstypes.ObservableTree]
         List of lsstypes objects to process.
     last_dim : str
         Name of the last (feature) dimension, used to extract coordinates
@@ -84,7 +85,7 @@ def lsstypes_postprocess(
     last_dim_dict = {last_dim: d0.flatten(level=None)[0].coords(last_dim)}
     coords = {**get, **last_dim_dict}
 
-    def lsstypes_match(d: object) -> object:
+    def lsstypes_match(d: LsstypeObject) -> LsstypeObject:
         return d.match(d0)
 
     data_out = np.asarray(
@@ -408,8 +409,9 @@ def split_test_set(
 
     data_vars = [ds[v] for v in to_split]
     for v_in, v_out in split_vars(*data_vars, **filters):
-        v_in.name = v_in.name + "_test"
-        v_out.name = v_out.name + "_train"
+        # NOTE: cast to str to avoid type issues
+        v_in.name = str(v_in.name) + "_test"
+        v_out.name = str(v_out.name) + "_train"
 
         # Mark filtered dimensions that will be filled with NaNs
         v_in.attrs["nan_dims"] = list(filters)

--- a/scripts/emc/measurements/compression/__init__.py
+++ b/scripts/emc/measurements/compression/__init__.py
@@ -1,0 +1,1 @@
+"""EMC measurement compression scripts."""

--- a/scripts/emc/measurements/compression/_common.py
+++ b/scripts/emc/measurements/compression/_common.py
@@ -1,0 +1,279 @@
+"""Shared utilities for EMC measurement compression scripts."""
+
+import argparse
+import logging
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import xarray
+
+from acm import setup_logging
+from acm.utils.default import cosmo_list
+from acm.utils.paths import lookup_registry_path
+from acm.utils.xarray import dataset_to_dict
+
+logger = logging.getLogger(__name__)
+
+TEST_FILTERS = {"cosmo_idx": [0, 1, 2, 3, 4, 13]}
+
+Reader = Callable[[list[Path]], Any]
+Postprocessor = Callable[[Sequence[Any]], tuple[np.ndarray, dict]]
+BuildSpec = Callable[[argparse.Namespace], "CompressionSpec"]
+
+
+@dataclass
+class CompressionSpec:
+    """Configuration for a single EMC statistic compression script."""
+
+    stat_name: str
+    observable_cls: type
+    base_root: str
+    base_pattern: str
+    reader: Reader
+    postprocess: Postprocessor
+    base_ignore_index: list[str] = field(default_factory=list)
+    covariance_root: str | None = None
+    covariance_pattern: str | None = None
+    covariance_reader: Reader | None = None
+    covariance_postprocess: Postprocessor | None = None
+    covariance_ignore_index: list[str] = field(default_factory=list)
+    align_covariance_last_dim: bool = True
+
+
+def parse_int_list(value: str | Sequence[int]) -> list[int]:
+    """Parse comma-separated integer values from CLI input."""
+    if isinstance(value, str):
+        return [int(item) for item in value.split(",") if item]
+    return [int(item) for item in value]
+
+
+def parse_str_list(value: str | Sequence[str]) -> list[str]:
+    """Parse comma-separated string values from CLI input."""
+    if isinstance(value, str):
+        return [item for item in value.split(",") if item]
+    return list(value)
+
+
+def add_common_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add common EMC compression CLI arguments."""
+    parser.add_argument("--n_hod", type=int, default=250)
+    parser.add_argument("--add_covariance", action="store_true")
+    parser.add_argument("--save_to", type=str, default=None)
+    parser.add_argument("--phase", type=int, default=0)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--cosmos", type=parse_int_list, default=None)
+    parser.add_argument("--no_test_split", action="store_true")
+
+
+def single_file_reader(files: list[Path], loader: Callable[[Path], Any]) -> Any:
+    """Read a group that is expected to contain exactly one file."""
+    if len(files) != 1:
+        raise ValueError(f"Expected exactly one file per group, got {len(files)}")
+    return loader(files[0])
+
+
+def filter_measurement_groups(
+    groups: dict[tuple, list[Path]],
+    index_arrays: dict[str, list],
+    cosmos: Sequence[int],
+    phase: int,
+    seed: int,
+) -> tuple[dict[tuple, list[Path]], dict[str, list]]:
+    """Filter groups to the requested cosmologies, phase, and seed."""
+    requested_cosmos = {f"{cosmo_idx:03d}" for cosmo_idx in cosmos}
+    filtered_groups: dict[tuple, list[Path]] = {}
+    filtered_index_arrays = {key: [] for key in index_arrays}
+
+    for key, files in groups.items():
+        key_dict = dict(key)
+        if "cosmo_idx" in key_dict and key_dict["cosmo_idx"] not in requested_cosmos:
+            continue
+        if "phase_idx" in key_dict and key_dict["phase_idx"] != f"{phase:03d}":
+            continue
+        if "seed" in key_dict and key_dict["seed"] != str(seed):
+            continue
+
+        filtered_groups[key] = files
+        for name, values in filtered_index_arrays.items():
+            values.append(key_dict[name])
+
+    return filtered_groups, filtered_index_arrays
+
+
+def limit_hods(
+    groups: dict[tuple, list[Path]],
+    index_arrays: dict[str, list],
+    n_hod: int,
+    group_by: Sequence[str] = ("cosmo_idx", "phase_idx", "seed"),
+    hod_key: str = "hod_idx",
+) -> tuple[dict[tuple, list[Path]], dict[str, list]]:
+    """Keep the first ``n_hod`` HOD groups within each sample subgroup."""
+    if hod_key not in index_arrays:
+        raise ValueError(f"Missing expected HOD index '{hod_key}'")
+
+    counts: dict[tuple, int] = {}
+    kept_groups: dict[tuple, list[Path]] = {}
+    kept_index_arrays = {key: [] for key in index_arrays}
+
+    for key, files in groups.items():
+        key_dict = dict(key)
+        group_key = tuple(key_dict[name] for name in group_by if name in key_dict)
+        count = counts.get(group_key, 0)
+        if count >= n_hod:
+            continue
+
+        counts[group_key] = count + 1
+        kept_groups[key] = files
+        for name, values in kept_index_arrays.items():
+            values.append(key_dict[name])
+
+    if not kept_groups:
+        raise ValueError("No measurement groups matched the requested filters")
+
+    short_groups = {key: count for key, count in counts.items() if count < n_hod}
+    if short_groups:
+        raise ValueError(
+            f"Some {tuple(group_by)} groups have fewer than n_hod={n_hod} HODs: "
+            f"{short_groups}"
+        )
+
+    return kept_groups, kept_index_arrays
+
+
+def align_covariance_last_dim(
+    covariance_y: xarray.DataArray, y: xarray.DataArray
+) -> xarray.DataArray:
+    """Align covariance's last coordinate to the compressed data coordinate."""
+    covariance_last_dim = covariance_y.dims[-1]
+    y_last_dim = y.dims[-1]
+    covariance_coord = covariance_y.coords[covariance_last_dim]
+    y_coord = y.coords[y_last_dim]
+
+    if covariance_coord.shape != y_coord.shape:
+        raise ValueError(
+            "Cannot align covariance last dimension due to shape mismatch: "
+            f"{covariance_coord.shape} vs {y_coord.shape}"
+        )
+
+    return covariance_y.assign_coords({covariance_last_dim: np.asarray(y_coord)})
+
+
+def compress_dataset(
+    spec: CompressionSpec,
+    paths: dict[str, str],
+    n_hod: int,
+    add_covariance: bool,
+    save_to: str | Path | None,
+    cosmos: Sequence[int],
+    phase: int,
+    seed: int,
+    test_filters: dict[str, list] | None,
+) -> xarray.Dataset:
+    """Compress one EMC statistic into an xarray dataset."""
+    from acm.utils.compression import (
+        collect_measurements,
+        compress_measurements,
+        split_test_set,
+    )
+
+    measurements_dir = Path(paths["measurements_dir"])
+    base_groups, base_index_arrays = collect_measurements(
+        root_dir=measurements_dir / spec.base_root,
+        glob_pattern=spec.base_pattern,
+        ignore_index=spec.base_ignore_index,
+    )
+    base_groups, base_index_arrays = filter_measurement_groups(
+        base_groups,
+        base_index_arrays,
+        cosmos=cosmos,
+        phase=phase,
+        seed=seed,
+    )
+    base_groups, base_index_arrays = limit_hods(
+        base_groups,
+        base_index_arrays,
+        n_hod=n_hod,
+    )
+
+    y = compress_measurements(
+        groups=base_groups,
+        index_arrays=base_index_arrays,
+        reindex=["hod_idx"],
+        reindex_group_by=["cosmo_idx", "phase_idx", "seed"],
+        reader=spec.reader,
+        postprocess=spec.postprocess,
+    ).rename("y")
+    x = spec.observable_cls.compress_x(
+        paths=paths,
+        cosmos=list(cosmos),
+        n_hod=n_hod,
+        phase=phase,
+        seed=seed,
+    )
+
+    data_vars: dict[str, xarray.DataArray] = {"x": x, "y": y}
+    if add_covariance:
+        if spec.covariance_root is None or spec.covariance_pattern is None:
+            raise ValueError(f"No covariance compression configured for {spec.stat_name}")
+        cov_groups, cov_index_arrays = collect_measurements(
+            root_dir=measurements_dir / spec.covariance_root,
+            glob_pattern=spec.covariance_pattern,
+            ignore_index=spec.covariance_ignore_index,
+        )
+        covariance_y = compress_measurements(
+            groups=cov_groups,
+            index_arrays=cov_index_arrays,
+            reader=spec.covariance_reader or spec.reader,
+            postprocess=spec.covariance_postprocess or spec.postprocess,
+        ).rename("covariance_y")
+        if spec.align_covariance_last_dim:
+            covariance_y = align_covariance_last_dim(covariance_y, y)
+        data_vars["covariance_y"] = covariance_y
+
+    dataset = xarray.Dataset(data_vars=data_vars)
+    if test_filters is not None:
+        dataset = split_test_set(dataset, test_filters)
+
+    if save_to is not None:
+        save_to = Path(save_to)
+        save_to.mkdir(parents=True, exist_ok=True)
+        save_fn = save_to / f"{spec.stat_name}.npy"
+        payload = np.array(dataset_to_dict(dataset), dtype=object)
+        np.save(save_fn, payload)
+        logger.info("Saved compressed %s data to %s", spec.stat_name, save_fn)
+
+    return dataset
+
+
+def run_cli(
+    build_spec: BuildSpec,
+    description: str,
+    add_arguments: Callable[[argparse.ArgumentParser], None] | None = None,
+) -> None:
+    """Parse CLI args, build a compression spec, and run compression."""
+    parser = argparse.ArgumentParser(description=description)
+    add_common_arguments(parser)
+    if add_arguments is not None:
+        add_arguments(parser)
+    args = parser.parse_args()
+
+    setup_logging()
+    paths = lookup_registry_path("projects.yaml", "emc")
+    save_to = args.save_to if args.save_to is not None else paths["data_dir"]
+    cosmos = args.cosmos if args.cosmos is not None else cosmo_list
+    test_filters = None if args.no_test_split else TEST_FILTERS
+
+    compress_dataset(
+        spec=build_spec(args),
+        paths=paths,
+        n_hod=args.n_hod,
+        add_covariance=args.add_covariance,
+        save_to=save_to,
+        cosmos=cosmos,
+        phase=args.phase,
+        seed=args.seed,
+        test_filters=test_filters,
+    )

--- a/scripts/emc/measurements/compression/compress_bispectrum.py
+++ b/scripts/emc/measurements/compression/compress_bispectrum.py
@@ -1,0 +1,90 @@
+"""Compress EMC bispectrum measurements."""
+
+import argparse
+from collections.abc import Sequence
+
+import numpy as np
+
+from _common import CompressionSpec, run_cli, single_file_reader
+
+
+def add_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add bispectrum-specific CLI arguments."""
+    parser.add_argument("--kmin", type=float, default=0.016)
+    parser.add_argument("--kmax", type=float, default=0.285)
+    parser.add_argument("--rebin", type=int, default=3)
+    parser.add_argument("--ells", type=str, default="0,2")
+
+
+def parse_ells(value: str) -> list[int]:
+    """Parse multipole values from a comma-separated string."""
+    return [int(item) for item in value.split(",") if item]
+
+
+def bispectrum_reader(files):
+    """Read one jaxpower bispectrum measurement."""
+    from jaxpower import read
+
+    return single_file_reader(files, read)
+
+
+def make_bispectrum_postprocess(
+    kmin: float,
+    kmax: float,
+    rebin: int,
+    ells: Sequence[int],
+):
+    """Build a postprocessor for jaxpower bispectrum measurements."""
+
+    def postprocess(data):
+        rows = []
+        bin_idx = None
+        for measurement in data:
+            measurement = measurement.select(k=slice(0, None, rebin)).select(
+                k=(kmin, kmax)
+            )
+            poles = [measurement.get(ell) for ell in ells]
+            k = poles[0].coords("k")
+            weights = k.prod(axis=1) / 1e5
+            rows.append([weights * pole.value().real for pole in poles])
+            if bin_idx is None:
+                bin_idx = np.arange(len(k))
+        return np.asarray(rows), {"ells": list(ells), "bin_idx": bin_idx}
+
+    return postprocess
+
+
+def build_spec(args: argparse.Namespace) -> CompressionSpec:
+    """Build the compression spec for bispectrum measurements."""
+    from acm.observables.emc.bispectrum_module import GalaxyBispectrumMultipoles
+
+    ells = parse_ells(args.ells)
+    postprocess = make_bispectrum_postprocess(args.kmin, args.kmax, args.rebin, ells)
+    return CompressionSpec(
+        stat_name="bispectrum",
+        observable_cls=GalaxyBispectrumMultipoles,
+        base_root="base/bispectrum",
+        base_pattern=(
+            "c{cosmo_idx}_ph{phase_idx}/seed{seed}/"
+            "mesh3_spectrum_poles_*_hod{hod_idx}.h5"
+        ),
+        reader=bispectrum_reader,
+        postprocess=postprocess,
+        covariance_root="small/bispectrum",
+        covariance_pattern="mesh3_spectrum_poles_ph{phase_idx}.h5",
+        covariance_reader=bispectrum_reader,
+        covariance_postprocess=postprocess,
+    )
+
+
+def main() -> None:
+    """Run bispectrum compression from the command line."""
+    run_cli(
+        build_spec,
+        description="Compress EMC bispectrum measurements.",
+        add_arguments=add_arguments,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/emc/measurements/compression/compress_density_split.py
+++ b/scripts/emc/measurements/compression/compress_density_split.py
@@ -1,0 +1,140 @@
+"""Shared density-split compression definitions."""
+
+import argparse
+from collections.abc import Sequence
+
+import numpy as np
+
+from _common import CompressionSpec, run_cli, single_file_reader
+
+
+def add_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add density-split-specific CLI arguments."""
+    parser.add_argument("--smin", type=float, default=0.0)
+    parser.add_argument("--smax", type=float, default=150.0)
+    parser.add_argument("--rebin", type=int, default=4)
+    parser.add_argument("--ells", type=str, default="0,2")
+    parser.add_argument("--quantiles", type=str, default="0,1,3,4")
+
+
+def parse_ints(value: str) -> list[int]:
+    """Parse integer values from a comma-separated string."""
+    return [int(item) for item in value.split(",") if item]
+
+
+def density_split_reader(files):
+    """Read one density-split base measurement."""
+
+    def load(path):
+        return np.load(path, allow_pickle=True)
+
+    return single_file_reader(files, load)
+
+
+def density_split_covariance_reader(files):
+    """Read one density-split covariance measurement."""
+    from acm.estimators.galaxy_clustering.base import BaseEstimator
+
+    return single_file_reader(files, BaseEstimator.read)
+
+
+def make_density_split_postprocess(
+    smin: float,
+    smax: float,
+    rebin: int,
+    ells: Sequence[int],
+    quantiles: Sequence[int],
+):
+    """Build a postprocessor for density-split base measurements."""
+
+    def postprocess(data):
+        rows = []
+        s = None
+        for measurement in data:
+            quantile_rows = []
+            for quantile in quantiles:
+                result = measurement[quantile][::rebin]
+                result.select((smin, smax))
+                s, multipoles = result(ells=ells, return_sep=True)
+                quantile_rows.append(
+                    np.concatenate(multipoles).reshape(len(ells), -1)
+                )
+            rows.append(quantile_rows)
+        return (
+            np.asarray(rows),
+            {"quantiles": list(quantiles), "ells": list(ells), "s": s},
+        )
+
+    return postprocess
+
+
+def make_density_split_covariance_postprocess(
+    smin: float,
+    smax: float,
+    rebin: int,
+    ells: Sequence[int],
+    quantiles: Sequence[int],
+):
+    """Build a postprocessor for density-split covariance measurements."""
+
+    def postprocess(data):
+        rows = []
+        s = None
+        for measurement in data:
+            quantile_rows = []
+            for quantile in quantiles:
+                xi = measurement.get(quantiles=quantile).select(
+                    s=slice(0, None, rebin)
+                )
+                xi = xi.select(s=(smin, smax))
+                poles = xi.project(ells=ells)
+                s = poles.get(ells=ells[0]).coords("s")
+                multipoles = [poles.get(ells=ell).value() for ell in ells]
+                quantile_rows.append(
+                    np.concatenate(multipoles).reshape(len(ells), -1)
+                )
+            rows.append(quantile_rows)
+        return (
+            np.asarray(rows),
+            {"quantiles": list(quantiles), "ells": list(ells), "s": s},
+        )
+
+    return postprocess
+
+
+def build_density_split_spec(
+    args: argparse.Namespace,
+    stat_name: str,
+    measurement_root: str,
+    observable_cls: type,
+) -> CompressionSpec:
+    """Build a compression spec for a density-split statistic."""
+    ells = parse_ints(args.ells)
+    quantiles = parse_ints(args.quantiles)
+    return CompressionSpec(
+        stat_name=stat_name,
+        observable_cls=observable_cls,
+        base_root="base/density_split",
+        base_pattern=(
+            "c{cosmo_idx}_ph{phase_idx}/seed{seed}/"
+            f"{measurement_root}_poles_*_hod{{hod_idx}}.npy"
+        ),
+        reader=density_split_reader,
+        postprocess=make_density_split_postprocess(
+            args.smin, args.smax, args.rebin, ells, quantiles
+        ),
+        covariance_root="small/density_split",
+        covariance_pattern=f"{measurement_root}_poles_ph{{phase_idx}}.h5",
+        covariance_reader=density_split_covariance_reader,
+        covariance_postprocess=make_density_split_covariance_postprocess(
+            args.smin, args.smax, args.rebin, ells, quantiles
+        ),
+    )
+
+
+def run_density_split_cli(
+    build_spec,
+    description: str,
+) -> None:
+    """Run a density-split compression CLI."""
+    run_cli(build_spec, description=description, add_arguments=add_arguments)

--- a/scripts/emc/measurements/compression/compress_ds_xiqg.py
+++ b/scripts/emc/measurements/compression/compress_ds_xiqg.py
@@ -1,0 +1,31 @@
+"""Compress EMC density-split quantile-galaxy correlation measurements."""
+
+import argparse
+
+from compress_density_split import build_density_split_spec, run_density_split_cli
+
+
+def build_spec(args: argparse.Namespace):
+    """Build the compression spec for ds_xiqg measurements."""
+    from acm.observables.emc.density_split_module import (
+        DensitySplitQuantileGalaxyCorrelationFunctionMultipoles,
+    )
+
+    return build_density_split_spec(
+        args,
+        stat_name="ds_xiqg",
+        measurement_root="dsc_xiqg",
+        observable_cls=DensitySplitQuantileGalaxyCorrelationFunctionMultipoles,
+    )
+
+
+def main() -> None:
+    """Run ds_xiqg compression from the command line."""
+    run_density_split_cli(
+        build_spec,
+        description="Compress EMC density-split quantile-galaxy measurements.",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/emc/measurements/compression/compress_ds_xiqq.py
+++ b/scripts/emc/measurements/compression/compress_ds_xiqq.py
@@ -1,0 +1,31 @@
+"""Compress EMC density-split quantile autocorrelation measurements."""
+
+import argparse
+
+from compress_density_split import build_density_split_spec, run_density_split_cli
+
+
+def build_spec(args: argparse.Namespace):
+    """Build the compression spec for ds_xiqq measurements."""
+    from acm.observables.emc.density_split_module import (
+        DensitySplitQuantileCorrelationFunctionMultipoles,
+    )
+
+    return build_density_split_spec(
+        args,
+        stat_name="ds_xiqq",
+        measurement_root="dsc_xiqq",
+        observable_cls=DensitySplitQuantileCorrelationFunctionMultipoles,
+    )
+
+
+def main() -> None:
+    """Run ds_xiqq compression from the command line."""
+    run_density_split_cli(
+        build_spec,
+        description="Compress EMC density-split quantile autocorrelation measurements.",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/emc/measurements/compression/compress_minkowski.py
+++ b/scripts/emc/measurements/compression/compress_minkowski.py
@@ -1,0 +1,88 @@
+"""Compress EMC Minkowski functional measurements."""
+
+import argparse
+from collections.abc import Mapping
+
+import numpy as np
+
+from _common import CompressionSpec, run_cli, single_file_reader
+
+DEFAULT_THRESHOLD_INDEX = (
+    "/pscratch/sd/e/epaillas/emc/Threshold_index_for_MFs_with_Rg5_7_10_15.npy"
+)
+
+
+def add_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add Minkowski-specific CLI arguments."""
+    parser.add_argument("--threshold_index", type=str, default=DEFAULT_THRESHOLD_INDEX)
+
+
+def minkowski_reader(files):
+    """Read one Minkowski measurement."""
+
+    def load(path):
+        return np.load(path, allow_pickle=True).item()
+
+    return single_file_reader(files, load)
+
+
+def make_minkowski_postprocess(threshold_index: Mapping[str, np.ndarray]):
+    """Build a postprocessor for Minkowski measurements."""
+
+    def postprocess(data):
+        rows = []
+        for measurement in data:
+            functionals = []
+            for radius in [5, 7, 10, 15]:
+                smoothing_key = f"Rg{radius}"
+                for functional_idx in range(4):
+                    functionals.append(
+                        measurement[smoothing_key][
+                            threshold_index[f"Threshold_index_{smoothing_key}"][
+                                functional_idx
+                            ],
+                            functional_idx,
+                        ]
+                        * (10 * radius) ** functional_idx
+                    )
+            rows.append(np.concatenate(functionals))
+        data_out = np.asarray(rows)
+        return data_out, {"bin_idx": np.arange(data_out.shape[-1])}
+
+    return postprocess
+
+
+def build_spec(args: argparse.Namespace) -> CompressionSpec:
+    """Build the compression spec for Minkowski measurements."""
+    from acm.observables.emc.minkowski_module import MinkowskiFunctionals
+
+    threshold_index = np.load(args.threshold_index, allow_pickle=True).item()
+    postprocess = make_minkowski_postprocess(threshold_index)
+    return CompressionSpec(
+        stat_name="minkowski",
+        observable_cls=MinkowskiFunctionals,
+        base_root="base/minkowski",
+        base_pattern=(
+            "c{cosmo_idx}_ph{phase_idx}/seed{seed}/"
+            "minkowski_*_hod{hod_idx}.npy"
+        ),
+        reader=minkowski_reader,
+        postprocess=postprocess,
+        covariance_root="small/minkowski",
+        covariance_pattern="minkowski_ph{phase_idx}.npy",
+        covariance_reader=minkowski_reader,
+        covariance_postprocess=postprocess,
+    )
+
+
+def main() -> None:
+    """Run Minkowski compression from the command line."""
+    run_cli(
+        build_spec,
+        description="Compress EMC Minkowski functional measurements.",
+        add_arguments=add_arguments,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/emc/measurements/compression/compress_projected_tpcf.py
+++ b/scripts/emc/measurements/compression/compress_projected_tpcf.py
@@ -1,0 +1,60 @@
+"""Compress EMC projected TPCF measurements."""
+
+import argparse
+
+import numpy as np
+
+from _common import CompressionSpec, run_cli, single_file_reader
+
+
+def projected_tpcf_reader(files):
+    """Read one projected TPCF measurement."""
+    from pycorr import TwoPointCorrelationFunction
+
+    return single_file_reader(files, TwoPointCorrelationFunction.load)
+
+
+def projected_tpcf_postprocess(data):
+    """Convert projected TPCF measurements to an array plus coordinates."""
+    rows = []
+    r_p = None
+    for measurement in data:
+        r_p, w_p = measurement(pimax=None, return_sep=True)
+        rows.append(w_p)
+    return np.asarray(rows), {"r_p": r_p}
+
+
+def build_spec(args: argparse.Namespace) -> CompressionSpec:
+    """Build the compression spec for projected TPCF measurements."""
+    del args
+    from acm.observables.emc.projected_tpcf_module import (
+        ProjectedGalaxyCorrelationFunction,
+    )
+
+    return CompressionSpec(
+        stat_name="projected_tpcf",
+        observable_cls=ProjectedGalaxyCorrelationFunction,
+        base_root="base/projected_tpcf",
+        base_pattern=(
+            "c{cosmo_idx}_ph{phase_idx}/seed{seed}/"
+            "tpcf_rppi_*_hod{hod_idx}.npy"
+        ),
+        reader=projected_tpcf_reader,
+        postprocess=projected_tpcf_postprocess,
+        covariance_root="small/projected_tpcf",
+        covariance_pattern="tpcf_rppi_ph{phase_idx}.npy",
+        covariance_reader=projected_tpcf_reader,
+        covariance_postprocess=projected_tpcf_postprocess,
+    )
+
+
+def main() -> None:
+    """Run projected TPCF compression from the command line."""
+    run_cli(
+        build_spec,
+        description="Compress EMC projected TPCF measurements.",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/emc/measurements/compression/compress_recon_spectrum.py
+++ b/scripts/emc/measurements/compression/compress_recon_spectrum.py
@@ -1,0 +1,49 @@
+"""Compress EMC reconstructed power spectrum measurements."""
+
+import argparse
+
+from compress_spectrum import (
+    add_arguments,
+    make_spectrum_postprocess,
+    parse_ells,
+    spectrum_reader,
+)
+from _common import CompressionSpec, run_cli
+
+
+def build_spec(args: argparse.Namespace) -> CompressionSpec:
+    """Build the compression spec for reconstructed power spectrum measurements."""
+    from acm.observables.emc.recon_spectrum_module import (
+        ReconstructedGalaxyPowerSpectrumMultipoles,
+    )
+
+    ells = parse_ells(args.ells)
+    postprocess = make_spectrum_postprocess(args.kmin, args.kmax, args.rebin, ells)
+    return CompressionSpec(
+        stat_name="recon_spectrum",
+        observable_cls=ReconstructedGalaxyPowerSpectrumMultipoles,
+        base_root="base/recon_spectrum",
+        base_pattern=(
+            "c{cosmo_idx}_ph{phase_idx}/seed{seed}/"
+            "mesh2_recon_spectrum_poles_*_hod{hod_idx}.h5"
+        ),
+        reader=spectrum_reader,
+        postprocess=postprocess,
+        covariance_root="small/recon_spectrum",
+        covariance_pattern="mesh2_recon_spectrum_poles_ph{phase_idx}.h5",
+        covariance_reader=spectrum_reader,
+        covariance_postprocess=postprocess,
+    )
+
+
+def main() -> None:
+    """Run reconstructed power spectrum compression from the command line."""
+    run_cli(
+        build_spec,
+        description="Compress EMC reconstructed power spectrum measurements.",
+        add_arguments=add_arguments,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/emc/measurements/compression/compress_spectrum.py
+++ b/scripts/emc/measurements/compression/compress_spectrum.py
@@ -1,0 +1,82 @@
+"""Compress EMC power spectrum measurements with generic compression utilities."""
+
+import argparse
+from collections.abc import Sequence
+
+import numpy as np
+
+from _common import CompressionSpec, run_cli, single_file_reader
+
+
+def add_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add power-spectrum-specific CLI arguments."""
+    parser.add_argument("--kmin", type=float, default=0.0126)
+    parser.add_argument("--kmax", type=float, default=0.7)
+    parser.add_argument("--rebin", type=int, default=13)
+    parser.add_argument("--ells", type=str, default="0,2,4")
+
+
+def parse_ells(value: str) -> list[int]:
+    """Parse multipole values from a comma-separated string."""
+    return [int(item) for item in value.split(",") if item]
+
+
+def spectrum_reader(files):
+    """Read one jaxpower power spectrum measurement."""
+    from jaxpower import read
+
+    return single_file_reader(files, read)
+
+
+def make_spectrum_postprocess(kmin: float, kmax: float, rebin: int, ells: Sequence[int]):
+    """Build a postprocessor for jaxpower power spectrum measurements."""
+
+    def postprocess(data):
+        rows = []
+        k = None
+        for measurement in data:
+            measurement = measurement.select(k=slice(0, None, rebin)).select(
+                k=(kmin, kmax)
+            )
+            poles = [measurement.get(ell) for ell in ells]
+            k = poles[0].coords("k")
+            rows.append(np.concatenate(poles).reshape(len(ells), -1))
+        return np.asarray(rows), {"ells": list(ells), "k": k}
+
+    return postprocess
+
+
+def build_spec(args: argparse.Namespace) -> CompressionSpec:
+    """Build the compression spec for power spectrum measurements."""
+    from acm.observables.emc.spectrum_module import GalaxyPowerSpectrumMultipoles
+
+    ells = parse_ells(args.ells)
+    postprocess = make_spectrum_postprocess(args.kmin, args.kmax, args.rebin, ells)
+    return CompressionSpec(
+        stat_name="spectrum",
+        observable_cls=GalaxyPowerSpectrumMultipoles,
+        base_root="base/spectrum",
+        base_pattern=(
+            "c{cosmo_idx}_ph{phase_idx}/seed{seed}/"
+            "mesh2_spectrum_poles_*_hod{hod_idx}.h5"
+        ),
+        reader=spectrum_reader,
+        postprocess=postprocess,
+        covariance_root="small/spectrum",
+        covariance_pattern="mesh2_spectrum_poles_ph{phase_idx}.h5",
+        covariance_reader=spectrum_reader,
+        covariance_postprocess=postprocess,
+    )
+
+
+def main() -> None:
+    """Run power spectrum compression from the command line."""
+    run_cli(
+        build_spec,
+        description="Compress EMC power spectrum measurements.",
+        add_arguments=add_arguments,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/emc/measurements/compression/compress_wst.py
+++ b/scripts/emc/measurements/compression/compress_wst.py
@@ -1,0 +1,86 @@
+"""Compress EMC wavelet scattering transform measurements."""
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+from _common import CompressionSpec, parse_str_list, run_cli
+
+DEFAULT_CONFIGS = "J4_L4_q1_sigma0.8,J4_L4_q1_sigma1.0,J5_L3_q0.8_sigma0.4"
+
+
+def add_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add WST-specific CLI arguments."""
+    parser.add_argument("--configs", type=parse_str_list, default=parse_str_list(DEFAULT_CONFIGS))
+
+
+def find_config(path: Path, configs: list[str]) -> str:
+    """Find the WST config name embedded in a measurement path."""
+    for part in path.parts:
+        if part in configs:
+            return part
+    raise ValueError(f"Could not infer WST config from {path}")
+
+
+def make_wst_reader(configs: list[str]):
+    """Build a reader that concatenates WST measurements across configs."""
+    from acm.observables.emc.wst_module import WaveletScatteringTransform
+
+    def reader(files):
+        by_config = {find_config(path, configs): path for path in files}
+        missing = [config for config in configs if config not in by_config]
+        if missing:
+            raise ValueError(f"Missing WST config files for {missing}")
+
+        coeffs = []
+        for config in configs:
+            data = np.load(by_config[config], allow_pickle=True)
+            coeffs.append(WaveletScatteringTransform.renorm_wst(data, config=config)[1:])
+        return np.concatenate(coeffs)
+
+    return reader
+
+
+def wst_postprocess(data):
+    """Convert concatenated WST coefficients to an array plus coordinates."""
+    data_out = np.asarray(data)
+    return data_out, {"bin_idx": np.arange(data_out.shape[-1])}
+
+
+def build_spec(args: argparse.Namespace) -> CompressionSpec:
+    """Build the compression spec for WST measurements."""
+    from acm.observables.emc.wst_module import WaveletScatteringTransform
+
+    configs = parse_str_list(args.configs)
+    reader = make_wst_reader(configs)
+    return CompressionSpec(
+        stat_name="wst",
+        observable_cls=WaveletScatteringTransform,
+        base_root="base/wst",
+        base_pattern=(
+            "{config}/c{cosmo_idx}_ph{phase_idx}/seed{seed}/"
+            "wst_*_hod{hod_idx}.npy"
+        ),
+        base_ignore_index=["config"],
+        reader=reader,
+        postprocess=wst_postprocess,
+        covariance_root="small/wst",
+        covariance_pattern="{config}/wst_ph{phase_idx}.npy",
+        covariance_ignore_index=["config"],
+        covariance_reader=reader,
+        covariance_postprocess=wst_postprocess,
+    )
+
+
+def main() -> None:
+    """Run WST compression from the command line."""
+    run_cli(
+        build_spec,
+        description="Compress EMC WST measurements.",
+        add_arguments=add_arguments,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/acm/utils/test_compression.py
+++ b/tests/acm/utils/test_compression.py
@@ -7,6 +7,7 @@ from acm.utils.compression import (
     collect_mocks,
     compress_mocks,
     reindex_samples,
+    split_test_set,
     reshape_to_coords,
 )
 
@@ -18,6 +19,11 @@ def test_reshape_to_coords_basic():
     result = reshape_to_coords(arr, coords)
     assert result.shape == (2, 3)
 
+def test_reshape_to_coords_single_dim():
+    arr = np.arange(3)
+    coords = {"a": [0, 1, 2]}
+    result = reshape_to_coords(arr, coords)
+    assert result.shape == (3,)
 
 def test_reshape_to_coords_mismatch_raises():
     arr = np.arange(5)
@@ -61,6 +67,18 @@ def test_cast_coords_float_not_rounded():
     result = cast_coords(d)
     assert result["k"].dtype == float
 
+def test_cast_coords_mixed():
+    # Each key is cast independently
+    d = {"idx": ["000", "001"], "k": ["0.1", "0.2"], "label": ["foo", "bar"]}
+    result = cast_coords(d)
+    assert result["idx"].dtype == int
+    assert result["k"].dtype == float
+    assert result["label"].dtype.kind in ("U", "O")
+
+
+def test_cast_coords_empty():
+    result = cast_coords({})
+    assert result == {}
 
 # %% reindex_samples
 
@@ -100,6 +118,92 @@ def test_reindex_samples_preserves_order():
     result = reindex_samples(index_arrays, reindex=["hod_idx"], group_by=["cosmo_idx"])
     assert result["hod_idx"] == [0, 1, 2]
 
+def test_reindex_samples_no_group_by_single_group():
+    index_arrays = {"hod_idx": ["006", "008", "010"]}
+    result = reindex_samples(index_arrays, reindex=["hod_idx"])
+    assert result["hod_idx"] == [0, 1, 2]
+
+
+def test_reindex_samples_multiple_reindex():
+    index_arrays = {
+        "cosmo_idx": ["000", "001"],
+        "hod_idx":   ["006", "008"],
+        "phase_idx": ["000", "001"],
+    }
+    result = reindex_samples(index_arrays, reindex=["hod_idx", "phase_idx"])
+    assert result["hod_idx"] == [0, 1]
+    assert result["phase_idx"] == [0, 1]
+    assert result["cosmo_idx"] == ["000", "001"]  # untouched
+
+
+def test_reindex_samples_already_zero_indexed():
+    index_arrays = {"hod_idx": ["000", "001", "002"]}
+    result = reindex_samples(index_arrays, reindex=["hod_idx"])
+    assert result["hod_idx"] == [0, 1, 2]
+
+
+def test_reindex_samples_multiple_group_by_keys():
+    index_arrays = {
+        "cosmo_idx": ["000", "000", "001", "001"],
+        "phase_idx": ["000", "000", "001", "001"],
+        "hod_idx":   ["006", "008", "006", "010"],
+    }
+    result = reindex_samples(
+        index_arrays, reindex=["hod_idx"], group_by=["cosmo_idx", "phase_idx"]
+    )
+    assert result["hod_idx"] == [0, 1, 0, 1]
+
+# %% split_test_set
+
+@pytest.fixture()
+def simple_dataset():
+    """A simple 2D dataset with cosmo and hod dimensions."""
+    x = xarray.DataArray(
+        np.random.rand(3, 4),
+        dims=["cosmo_idx", "hod_idx"],
+        coords={"cosmo_idx": [0, 1, 2], "hod_idx": [0, 1, 2, 3]},
+        name="x",
+    )
+    y = xarray.DataArray(
+        np.random.rand(3, 4),
+        dims=["cosmo_idx", "hod_idx"],
+        coords={"cosmo_idx": [0, 1, 2], "hod_idx": [0, 1, 2, 3]},
+        name="y",
+    )
+    return xarray.Dataset({"x": x, "y": y})
+
+
+def test_split_test_set_adds_test_train_variables(simple_dataset):
+    result = split_test_set(simple_dataset, filters={"cosmo_idx": [0, 1]})
+    assert "x_test" in result
+    assert "x_train" in result
+    assert "y_test" in result
+    assert "y_train" in result
+
+
+def test_split_test_set_nan_dims_attr(simple_dataset):
+    result = split_test_set(simple_dataset, filters={"cosmo_idx": [0, 1]})
+    assert result["x_test"].attrs["nan_dims"] == ["cosmo_idx"]
+    assert result["x_train"].attrs["nan_dims"] == ["cosmo_idx"]
+
+
+def test_split_test_set_missing_variable_raises(simple_dataset):
+    with pytest.raises(ValueError, match="not found"):
+        split_test_set(simple_dataset, filters={"cosmo_idx": [0]}, to_split=["z"])
+
+
+def test_split_test_set_custom_to_split(simple_dataset):
+    result = split_test_set(simple_dataset, filters={"cosmo_idx": [0, 1]}, to_split=["x"])
+    assert "x_test" in result
+    assert "x_train" in result
+    assert "y_test" not in result
+    assert "y_train" not in result
+
+
+def test_split_test_set_preserves_original_variables(simple_dataset):
+    result = split_test_set(simple_dataset, filters={"cosmo_idx": [0, 1]})
+    assert "x" in result
+    assert "y" in result
 
 # %% collect_mocks
 
@@ -154,6 +258,29 @@ def test_collect_mocks_correct_index_values(mock_file_tree):
     assert set(index_arrays["cosmo_idx"]) == {"000", "001"}
     assert set(index_arrays["hod_idx"]) == {"006", "008"}
 
+def test_collect_mocks_no_ignore_index(mock_file_tree):
+    groups, index_arrays = collect_mocks(mock_file_tree, GLOB_PATTERN)
+    # Without ignoring 'los', each (cosmo, phase, seed, hod, los) combo is its own group
+    assert "los" in index_arrays
+    assert all(len(files) == 1 for files in groups.values())
+
+
+def test_collect_mocks_all_indexes_tracked(mock_file_tree):
+    _, index_arrays = collect_mocks(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
+    assert set(index_arrays.keys()) == {"cosmo_idx", "phase_idx", "seed", "hod_idx"}
+
+
+def test_collect_mocks_empty_dir(tmp_path):
+    groups, index_arrays = collect_mocks(tmp_path, GLOB_PATTERN, ignore_index=["los"])
+    assert len(groups) == 0
+    assert all(len(v) == 0 for v in index_arrays.values())
+
+
+def test_collect_mocks_sorted_files(mock_file_tree):
+    # Files within each group should be sorted
+    groups, _ = collect_mocks(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
+    for files in groups.values():
+        assert files == sorted(files)
 
 # %% compress_mocks
 
@@ -182,6 +309,25 @@ def test_compress_mocks_sparse_grid_raises(tmp_path):
     groups, index_arrays = collect_mocks(tmp_path, GLOB_PATTERN, ignore_index=["los"])
     with pytest.raises(ValueError, match="sparse"):
         compress_mocks(groups, index_arrays, reader=_dummy_reader, postprocess=_dummy_postprocess)
+
+def test_compress_mocks_correct_shape(mock_file_tree):
+    groups, index_arrays = collect_mocks(mock_file_tree, GLOB_PATTERN, ignore_index=["los", "seed", "phase_idx"])
+    result = compress_mocks(groups, index_arrays, reader=_dummy_reader, postprocess=_dummy_postprocess)
+    # (n_hod=2, n_cosmo=2, n_features=2) with singleton dims dropped
+    assert result.shape == (2, 2, 2)
+
+
+def test_compress_mocks_reader_called_once_per_group(mock_file_tree):
+    groups, index_arrays = collect_mocks(mock_file_tree, GLOB_PATTERN, ignore_index=["los", "seed", "phase_idx"])
+    call_count = 0
+
+    def counting_reader(files):
+        nonlocal call_count
+        call_count += 1
+        return len(files)
+
+    compress_mocks(groups, index_arrays, reader=counting_reader, postprocess=_dummy_postprocess)
+    assert call_count == len(groups)
 
 def test_compress_mocks_output_is_dataarray(mock_file_tree):
     groups, index_arrays = collect_mocks(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
@@ -240,7 +386,7 @@ def test_compress_mocks_with_reindex(mock_file_tree):
 
 
 def test_compress_mocks_drop_singleton_dims(mock_file_tree):
-    groups, index_arrays = collect_mocks(mock_file_tree, GLOB_PATTERN, ignore_index=["los", "seed", "phase_idx"])
+    groups, index_arrays = collect_mocks(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
     result = compress_mocks(
         groups, index_arrays,
         drop_singleton_dims=True,
@@ -248,7 +394,24 @@ def test_compress_mocks_drop_singleton_dims(mock_file_tree):
         postprocess=_dummy_postprocess,
     )
     assert all(s > 1 for s in result.shape)
+    assert "phase_idx" not in result.coords
+    assert "seed" not in result.coords
+    assert "phase_idx" not in result.attrs["sample"]
+    assert "seed" not in result.attrs["sample"]
 
+def test_compress_mocks_no_drop_singleton_dims(mock_file_tree):
+    groups, index_arrays = collect_mocks(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
+    result = compress_mocks(
+        groups, index_arrays,
+        drop_singleton_dims=False,
+        reader=_dummy_reader,
+        postprocess=_dummy_postprocess,
+    )
+    # Singleton dims (phase, seed) should still be present
+    assert "phase_idx" in result.coords
+    assert "seed" in result.coords
+    assert "phase_idx" in result.attrs["sample"]
+    assert "seed" in result.attrs["sample"]
 
 def test_compress_mocks_data_values(mock_file_tree):
     groups, index_arrays = collect_mocks(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])

--- a/tests/acm/utils/test_compression.py
+++ b/tests/acm/utils/test_compression.py
@@ -1,0 +1,260 @@
+import numpy as np
+import pytest
+import xarray
+
+from acm.utils.compression import (
+    cast_coords,
+    collect_mocks,
+    compress_mocks,
+    reindex_samples,
+    reshape_to_coords,
+)
+
+# %% reshape_to_coords
+
+def test_reshape_to_coords_basic():
+    arr = np.arange(6)
+    coords = {"a": [0, 1], "b": [0, 1, 2]}
+    result = reshape_to_coords(arr, coords)
+    assert result.shape == (2, 3)
+
+
+def test_reshape_to_coords_mismatch_raises():
+    arr = np.arange(5)
+    coords = {"a": [0, 1], "b": [0, 1, 2]}
+    with pytest.raises(ValueError, match="Cannot reshape"):
+        reshape_to_coords(arr, coords)
+
+
+# %% cast_coords
+
+def test_cast_coords_int_strings():
+    d = {"idx": ["000", "001", "002"]}
+    result = cast_coords(d)
+    assert result["idx"].dtype == int
+    np.testing.assert_array_equal(result["idx"], [0, 1, 2])
+
+
+def test_cast_coords_float_strings():
+    d = {"k": ["0.1", "0.2", "0.35"]}
+    result = cast_coords(d)
+    assert result["k"].dtype == float
+    np.testing.assert_allclose(result["k"], [0.1, 0.2, 0.35])
+
+
+def test_cast_coords_non_numeric_strings():
+    d = {"label": ["foo", "bar"]}
+    result = cast_coords(d)
+    assert result["label"].dtype.kind in ("U", "O")  # string or object
+
+
+def test_cast_coords_whole_floats_cast_to_int():
+    # Whole-number floats should be downcast to int
+    d = {"ells": ["0.0", "2.0", "4.0"]}
+    result = cast_coords(d)
+    assert result["ells"].dtype == int
+
+
+def test_cast_coords_float_not_rounded():
+    # Non-whole floats must not be rounded to int
+    d = {"k": ["0.1", "0.15", "0.2"]}
+    result = cast_coords(d)
+    assert result["k"].dtype == float
+
+
+# %% reindex_samples
+
+def test_reindex_samples_global():
+    index_arrays = {
+        "cosmo_idx": ["000", "000", "001", "001"],
+        "hod_idx":   ["006", "008", "006", "010"],
+    }
+    result = reindex_samples(index_arrays, reindex=["hod_idx"])
+    # Global ordering: 006->0, 008->1, 010->2
+    assert result["hod_idx"] == [0, 1, 0, 2]
+    assert result["cosmo_idx"] == ["000", "000", "001", "001"]  # unchanged
+
+
+def test_reindex_samples_group_by():
+    index_arrays = {
+        "cosmo_idx": ["000", "000", "000", "001", "001", "001"],
+        "hod_idx":   ["006", "008", "010", "008", "010", "014"],
+    }
+    result = reindex_samples(index_arrays, reindex=["hod_idx"], group_by=["cosmo_idx"])
+    # Within each cosmo group, hod_idx is re-indexed from 0
+    assert result["hod_idx"] == [0, 1, 2, 0, 1, 2]
+
+
+def test_reindex_samples_missing_index_raises():
+    index_arrays = {"cosmo_idx": ["000", "001"]}
+    with pytest.raises(ValueError, match="not found"):
+        reindex_samples(index_arrays, reindex=["hod_idx"])
+
+
+def test_reindex_samples_preserves_order():
+    # Re-indexing should follow insertion order, not sorted order
+    index_arrays = {
+        "cosmo_idx": ["000", "000", "000"],
+        "hod_idx":   ["010", "006", "008"],  # not sorted
+    }
+    result = reindex_samples(index_arrays, reindex=["hod_idx"], group_by=["cosmo_idx"])
+    assert result["hod_idx"] == [0, 1, 2]
+
+
+# %% collect_mocks
+
+@pytest.fixture()
+def mock_file_tree(tmp_path):
+    """Create a minimal mock file tree and return the root path."""
+    files = [
+        "c000_ph000/seed0/hod006/power_spectrum_los_x.h5",
+        "c000_ph000/seed0/hod006/power_spectrum_los_y.h5",
+        "c000_ph000/seed0/hod008/power_spectrum_los_x.h5",
+        "c000_ph000/seed0/hod008/power_spectrum_los_y.h5",
+        "c001_ph000/seed0/hod006/power_spectrum_los_x.h5",
+        "c001_ph000/seed0/hod006/power_spectrum_los_y.h5",
+        "c001_ph000/seed0/hod008/power_spectrum_los_x.h5",
+        "c001_ph000/seed0/hod008/power_spectrum_los_y.h5",
+    ]
+    for f in files:
+        p = tmp_path / f
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.touch()
+    return tmp_path
+
+
+GLOB_PATTERN = "c{cosmo_idx}_ph{phase_idx}/seed{seed}/hod{hod_idx}/power_spectrum_los_{los}.h5"
+
+
+def test_collect_mocks_groups_by_index(mock_file_tree):
+    groups, index_arrays = collect_mocks(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
+    # 2*2 unique combinations of cosmo_idx and hod_idx, so 4 groups
+    assert len(groups) == 4
+
+
+def test_collect_mocks_ignored_index_files_are_grouped(mock_file_tree):
+    groups, _ = collect_mocks(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
+    # Each group should contain 2 files (los_x and los_y)
+    assert all(len(files) == 2 for files in groups.values())
+
+
+def test_collect_mocks_ignored_index_not_in_index_arrays(mock_file_tree):
+    _, index_arrays = collect_mocks(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
+    assert "los" not in index_arrays
+
+
+def test_collect_mocks_index_arrays_aligned(mock_file_tree):
+    _, index_arrays = collect_mocks(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
+    lengths = [len(v) for v in index_arrays.values()]
+    assert len(set(lengths)) == 1  # all same length
+
+
+def test_collect_mocks_correct_index_values(mock_file_tree):
+    _, index_arrays = collect_mocks(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
+    assert set(index_arrays["cosmo_idx"]) == {"000", "001"}
+    assert set(index_arrays["hod_idx"]) == {"006", "008"}
+
+
+# %% compress_mocks
+
+def _dummy_reader(files):
+    """Returns a simple sentinel object (just the count of files)."""
+    return len(files)
+
+
+def _dummy_postprocess(data, **kwargs):
+    """Returns a flat array of ones with shape (n_samples, n_features=2)."""
+    arr = np.ones((len(data), 2))
+    coords = {"feature": [0, 1]}
+    return arr, coords
+
+def test_compress_mocks_sparse_grid_raises(tmp_path):
+    """Sparse grids (missing index combinations) should raise a ValueError."""
+    files = [
+        "c000_ph000/seed0/hod006/power_spectrum_los_x.h5",
+        "c001_ph000/seed0/hod008/power_spectrum_los_x.h5",  # c001/hod006 and c000/hod008 are missing
+    ]
+    for f in files:
+        p = tmp_path / f
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.touch()
+
+    groups, index_arrays = collect_mocks(tmp_path, GLOB_PATTERN, ignore_index=["los"])
+    with pytest.raises(ValueError, match="sparse"):
+        compress_mocks(groups, index_arrays, reader=_dummy_reader, postprocess=_dummy_postprocess)
+
+def test_compress_mocks_output_is_dataarray(mock_file_tree):
+    groups, index_arrays = collect_mocks(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
+    result = compress_mocks(
+        groups, index_arrays,
+        reader=_dummy_reader,
+        postprocess=_dummy_postprocess,
+    )
+    assert isinstance(result, xarray.DataArray)
+
+
+def test_compress_mocks_sample_dims_in_coords(mock_file_tree):
+    groups, index_arrays = collect_mocks(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
+    result = compress_mocks(
+        groups, index_arrays,
+        reader=_dummy_reader,
+        postprocess=_dummy_postprocess,
+    )
+    for idx in ["cosmo_idx", "hod_idx"]:
+        assert idx in result.coords
+
+
+def test_compress_mocks_feature_dims_in_coords(mock_file_tree):
+    groups, index_arrays = collect_mocks(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
+    result = compress_mocks(
+        groups, index_arrays,
+        reader=_dummy_reader,
+        postprocess=_dummy_postprocess,
+    )
+    assert "feature" in result.coords
+
+
+def test_compress_mocks_attrs(mock_file_tree):
+    groups, index_arrays = collect_mocks(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
+    result = compress_mocks(
+        groups, index_arrays,
+        reader=_dummy_reader,
+        postprocess=_dummy_postprocess,
+    )
+    assert "sample" in result.attrs
+    assert "features" in result.attrs
+
+
+def test_compress_mocks_with_reindex(mock_file_tree):
+    groups, index_arrays = collect_mocks(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
+    result = compress_mocks(
+        groups, index_arrays,
+        reindex=["hod_idx"],
+        reindex_group_by=["cosmo_idx"],
+        reader=_dummy_reader,
+        postprocess=_dummy_postprocess,
+    )
+    # After reindexing, hod_idx coords should be contiguous integers from 0
+    hod_coords = result.coords["hod_idx"].values
+    assert set(hod_coords) == set(range(len(hod_coords)))
+
+
+def test_compress_mocks_drop_singleton_dims(mock_file_tree):
+    groups, index_arrays = collect_mocks(mock_file_tree, GLOB_PATTERN, ignore_index=["los", "seed", "phase_idx"])
+    result = compress_mocks(
+        groups, index_arrays,
+        drop_singleton_dims=True,
+        reader=_dummy_reader,
+        postprocess=_dummy_postprocess,
+    )
+    assert all(s > 1 for s in result.shape)
+
+
+def test_compress_mocks_data_values(mock_file_tree):
+    groups, index_arrays = collect_mocks(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
+    result = compress_mocks(
+        groups, index_arrays,
+        reader=_dummy_reader,
+        postprocess=_dummy_postprocess,
+    )
+    np.testing.assert_array_equal(result.values, np.ones(result.shape))

--- a/tests/acm/utils/test_compression.py
+++ b/tests/acm/utils/test_compression.py
@@ -4,154 +4,162 @@ import xarray
 
 from acm.utils.compression import (
     cast_coords,
-    collect_mocks,
-    compress_mocks,
+    collect_measurements,
+    compress_measurements,
     reindex_samples,
     split_test_set,
     reshape_to_coords,
 )
 
-# %% reshape_to_coords
 
-def test_reshape_to_coords_basic():
-    arr = np.arange(6)
-    coords = {"a": [0, 1], "b": [0, 1, 2]}
-    result = reshape_to_coords(arr, coords)
-    assert result.shape == (2, 3)
+class TestReshapeToCoords:
+    """Tests for the reshape_to_coords function."""
+    
+    def test_basic(self):
+        """Test that an array can be reshaped to match the provided coordinate lengths."""
+        arr = np.arange(6)
+        coords = {"a": [0, 1], "b": [0, 1, 2]}
+        result = reshape_to_coords(arr, coords)
+        assert result.shape == (2, 3)
 
-def test_reshape_to_coords_single_dim():
-    arr = np.arange(3)
-    coords = {"a": [0, 1, 2]}
-    result = reshape_to_coords(arr, coords)
-    assert result.shape == (3,)
+    def test_single_dim(self):
+        """Test that an array can be reshaped to a single dimension."""
+        arr = np.arange(3)
+        coords = {"a": [0, 1, 2]}
+        result = reshape_to_coords(arr, coords)
+        assert result.shape == (3,)
 
-def test_reshape_to_coords_mismatch_raises():
-    arr = np.arange(5)
-    coords = {"a": [0, 1], "b": [0, 1, 2]}
-    with pytest.raises(ValueError, match="Cannot reshape"):
-        reshape_to_coords(arr, coords)
-
-
-# %% cast_coords
-
-def test_cast_coords_int_strings():
-    d = {"idx": ["000", "001", "002"]}
-    result = cast_coords(d)
-    assert result["idx"].dtype == int
-    np.testing.assert_array_equal(result["idx"], [0, 1, 2])
+    def test_mismatch_raises(self):
+        """Test that a ValueError is raised if the array size does not match the product of coordinate lengths."""
+        arr = np.arange(5)
+        coords = {"a": [0, 1], "b": [0, 1, 2]}
+        with pytest.raises(ValueError, match="Cannot reshape"):
+            reshape_to_coords(arr, coords)
 
 
-def test_cast_coords_float_strings():
-    d = {"k": ["0.1", "0.2", "0.35"]}
-    result = cast_coords(d)
-    assert result["k"].dtype == float
-    np.testing.assert_allclose(result["k"], [0.1, 0.2, 0.35])
+class TestCastCoords:
+    """Tests for the cast_coords function."""
+    
+    def test_int_strings(self):
+        """Test that strings representing integers are cast to int."""
+        d = {"idx": ["000", "001", "002"]}
+        result = cast_coords(d)
+        assert result["idx"].dtype == int
+        np.testing.assert_array_equal(result["idx"], [0, 1, 2])
+
+    def test_float_strings(self):
+        """Test that strings representing floats are cast to float."""
+        d = {"k": ["0.1", "0.2", "0.35"]}
+        result = cast_coords(d)
+        assert result["k"].dtype == float
+        np.testing.assert_allclose(result["k"], [0.1, 0.2, 0.35])
+
+    def test_non_numeric_strings(self):
+        """Test that non-numeric strings are left as strings."""
+        d = {"label": ["foo", "bar"]}
+        result = cast_coords(d)
+        assert result["label"].dtype.kind in ("U", "O")  # string or object
+
+    def test_whole_floats_cast_to_int(self):
+        """Test that strings representing whole-number floats are cast to int."""
+        d = {"ells": ["0.0", "2.0", "4.0"]}
+        result = cast_coords(d)
+        assert result["ells"].dtype == int
+
+    def test_float_not_rounded(self):
+        """Test that strings representing non-whole floats are not rounded to int."""
+        d = {"k": ["0.1", "0.15", "0.2"]}
+        result = cast_coords(d)
+        assert result["k"].dtype == float
+
+    def test_mixed(self):
+        """Test that each key is cast independently based on its values."""
+        d = {"idx": ["000", "001"], "k": ["0.1", "0.2"], "label": ["foo", "bar"]}
+        result = cast_coords(d)
+        assert result["idx"].dtype == int
+        assert result["k"].dtype == float
+        assert result["label"].dtype.kind in ("U", "O")
+
+    def test_empty(self):
+        """Test that an empty dictionary is handled without error."""
+        result = cast_coords({})
+        assert result == {}
 
 
-def test_cast_coords_non_numeric_strings():
-    d = {"label": ["foo", "bar"]}
-    result = cast_coords(d)
-    assert result["label"].dtype.kind in ("U", "O")  # string or object
+class TestReindexSamples:
+    """Tests for the reindex_samples function."""
+    
+    def test_global(self):
+        """Test global reindexing without grouping."""
+        index_arrays = {
+            "cosmo_idx": ["000", "000", "001", "001"],
+            "hod_idx":   ["006", "008", "006", "010"],
+        }
+        result = reindex_samples(index_arrays, reindex=["hod_idx"])
+        # Global ordering: 006->0, 008->1, 010->2
+        assert result["hod_idx"] == [0, 1, 0, 2]
+        assert result["cosmo_idx"] == ["000", "000", "001", "001"]  # unchanged
 
+    def test_group_by(self):
+        """Test reindexing within groups defined by other index arrays."""
+        index_arrays = {
+            "cosmo_idx": ["000", "000", "000", "001", "001", "001"],
+            "hod_idx":   ["006", "008", "010", "008", "010", "014"],
+        }
+        result = reindex_samples(index_arrays, reindex=["hod_idx"], group_by=["cosmo_idx"])
+        # Within each cosmo group, hod_idx is re-indexed from 0
+        assert result["hod_idx"] == [0, 1, 2, 0, 1, 2]
 
-def test_cast_coords_whole_floats_cast_to_int():
-    # Whole-number floats should be downcast to int
-    d = {"ells": ["0.0", "2.0", "4.0"]}
-    result = cast_coords(d)
-    assert result["ells"].dtype == int
+    def test_missing_index_raises(self):
+        """Test that a ValueError is raised if a reindex key is not found in the index arrays."""
+        index_arrays = {"cosmo_idx": ["000", "001"]}
+        with pytest.raises(ValueError, match="not found"):
+            reindex_samples(index_arrays, reindex=["hod_idx"])
 
+    def test_preserves_order(self):
+        """Test that the re-indexing preserves the original order of samples within each group, not sorted order."""
+        index_arrays = {
+            "cosmo_idx": ["000", "000", "000"],
+            "hod_idx":   ["010", "006", "008"],  # not sorted
+        }
+        result = reindex_samples(index_arrays, reindex=["hod_idx"], group_by=["cosmo_idx"])
+        assert result["hod_idx"] == [0, 1, 2]
 
-def test_cast_coords_float_not_rounded():
-    # Non-whole floats must not be rounded to int
-    d = {"k": ["0.1", "0.15", "0.2"]}
-    result = cast_coords(d)
-    assert result["k"].dtype == float
+    def test_no_group_by_single_group(self):
+        """Test reindexing without grouping when all samples belong to a single group."""
+        index_arrays = {"hod_idx": ["006", "008", "010"]}
+        result = reindex_samples(index_arrays, reindex=["hod_idx"])
+        assert result["hod_idx"] == [0, 1, 2]
 
-def test_cast_coords_mixed():
-    # Each key is cast independently
-    d = {"idx": ["000", "001"], "k": ["0.1", "0.2"], "label": ["foo", "bar"]}
-    result = cast_coords(d)
-    assert result["idx"].dtype == int
-    assert result["k"].dtype == float
-    assert result["label"].dtype.kind in ("U", "O")
+    def test_multiple_reindex(self):
+        """Test reindexing multiple index arrays at once."""
+        index_arrays = {
+            "cosmo_idx": ["000", "001"],
+            "hod_idx":   ["006", "008"],
+            "phase_idx": ["000", "001"],
+        }
+        result = reindex_samples(index_arrays, reindex=["hod_idx", "phase_idx"])
+        assert result["hod_idx"] == [0, 1]
+        assert result["phase_idx"] == [0, 1]
+        assert result["cosmo_idx"] == ["000", "001"]  # untouched
 
+    def test_already_zero_indexed(self):
+        """Test that if the index is already zero-indexed, it remains unchanged."""
+        index_arrays = {"hod_idx": ["000", "001", "002"]}
+        result = reindex_samples(index_arrays, reindex=["hod_idx"])
+        assert result["hod_idx"] == [0, 1, 2]
 
-def test_cast_coords_empty():
-    result = cast_coords({})
-    assert result == {}
-
-# %% reindex_samples
-
-def test_reindex_samples_global():
-    index_arrays = {
-        "cosmo_idx": ["000", "000", "001", "001"],
-        "hod_idx":   ["006", "008", "006", "010"],
-    }
-    result = reindex_samples(index_arrays, reindex=["hod_idx"])
-    # Global ordering: 006->0, 008->1, 010->2
-    assert result["hod_idx"] == [0, 1, 0, 2]
-    assert result["cosmo_idx"] == ["000", "000", "001", "001"]  # unchanged
-
-
-def test_reindex_samples_group_by():
-    index_arrays = {
-        "cosmo_idx": ["000", "000", "000", "001", "001", "001"],
-        "hod_idx":   ["006", "008", "010", "008", "010", "014"],
-    }
-    result = reindex_samples(index_arrays, reindex=["hod_idx"], group_by=["cosmo_idx"])
-    # Within each cosmo group, hod_idx is re-indexed from 0
-    assert result["hod_idx"] == [0, 1, 2, 0, 1, 2]
-
-
-def test_reindex_samples_missing_index_raises():
-    index_arrays = {"cosmo_idx": ["000", "001"]}
-    with pytest.raises(ValueError, match="not found"):
-        reindex_samples(index_arrays, reindex=["hod_idx"])
-
-
-def test_reindex_samples_preserves_order():
-    # Re-indexing should follow insertion order, not sorted order
-    index_arrays = {
-        "cosmo_idx": ["000", "000", "000"],
-        "hod_idx":   ["010", "006", "008"],  # not sorted
-    }
-    result = reindex_samples(index_arrays, reindex=["hod_idx"], group_by=["cosmo_idx"])
-    assert result["hod_idx"] == [0, 1, 2]
-
-def test_reindex_samples_no_group_by_single_group():
-    index_arrays = {"hod_idx": ["006", "008", "010"]}
-    result = reindex_samples(index_arrays, reindex=["hod_idx"])
-    assert result["hod_idx"] == [0, 1, 2]
-
-
-def test_reindex_samples_multiple_reindex():
-    index_arrays = {
-        "cosmo_idx": ["000", "001"],
-        "hod_idx":   ["006", "008"],
-        "phase_idx": ["000", "001"],
-    }
-    result = reindex_samples(index_arrays, reindex=["hod_idx", "phase_idx"])
-    assert result["hod_idx"] == [0, 1]
-    assert result["phase_idx"] == [0, 1]
-    assert result["cosmo_idx"] == ["000", "001"]  # untouched
-
-
-def test_reindex_samples_already_zero_indexed():
-    index_arrays = {"hod_idx": ["000", "001", "002"]}
-    result = reindex_samples(index_arrays, reindex=["hod_idx"])
-    assert result["hod_idx"] == [0, 1, 2]
-
-
-def test_reindex_samples_multiple_group_by_keys():
-    index_arrays = {
-        "cosmo_idx": ["000", "000", "001", "001"],
-        "phase_idx": ["000", "000", "001", "001"],
-        "hod_idx":   ["006", "008", "006", "010"],
-    }
-    result = reindex_samples(
-        index_arrays, reindex=["hod_idx"], group_by=["cosmo_idx", "phase_idx"]
-    )
-    assert result["hod_idx"] == [0, 1, 0, 1]
+    def test_multiple_group_by_keys(self):
+        """Test grouping by multiple keys simultaneously."""
+        index_arrays = {
+            "cosmo_idx": ["000", "000", "001", "001"],
+            "phase_idx": ["000", "000", "001", "001"],
+            "hod_idx":   ["006", "008", "006", "010"],
+        }
+        result = reindex_samples(
+            index_arrays, reindex=["hod_idx"], group_by=["cosmo_idx", "phase_idx"]
+        )
+        assert result["hod_idx"] == [0, 1, 0, 1]
 
 # %% split_test_set
 
@@ -172,40 +180,43 @@ def simple_dataset():
     )
     return xarray.Dataset({"x": x, "y": y})
 
+class TestSplitTestSet:
+    """Tests for the split_test_set function."""
+    
+    def test_adds_test_train_variables(self, simple_dataset):
+        """Test that the output contains x_test, x_train, y_test, y_train."""
+        result = split_test_set(simple_dataset, filters={"cosmo_idx": [0, 1]})
+        assert "x_test" in result
+        assert "x_train" in result
+        assert "y_test" in result
+        assert "y_train" in result
 
-def test_split_test_set_adds_test_train_variables(simple_dataset):
-    result = split_test_set(simple_dataset, filters={"cosmo_idx": [0, 1]})
-    assert "x_test" in result
-    assert "x_train" in result
-    assert "y_test" in result
-    assert "y_train" in result
+    def test_nan_dims_attr(self, simple_dataset):
+        """Test that the 'nan_dims' attribute is set correctly on the test and train variables."""
+        result = split_test_set(simple_dataset, filters={"cosmo_idx": [0, 1]})
+        assert result["x_test"].attrs["nan_dims"] == ["cosmo_idx"]
+        assert result["x_train"].attrs["nan_dims"] == ["cosmo_idx"]
 
+    def test_missing_variable_raises(self, simple_dataset):
+        """Test that if a variable in to_split is missing from the dataset, a ValueError is raised."""
+        with pytest.raises(ValueError, match="not found"):
+            split_test_set(simple_dataset, filters={"cosmo_idx": [0]}, to_split=["z"])
 
-def test_split_test_set_nan_dims_attr(simple_dataset):
-    result = split_test_set(simple_dataset, filters={"cosmo_idx": [0, 1]})
-    assert result["x_test"].attrs["nan_dims"] == ["cosmo_idx"]
-    assert result["x_train"].attrs["nan_dims"] == ["cosmo_idx"]
+    def test_custom_to_split(self, simple_dataset):
+        """Test that only variables specified in to_split are split, and others are left unchanged."""
+        result = split_test_set(simple_dataset, filters={"cosmo_idx": [0, 1]}, to_split=["x"])
+        assert "x_test" in result
+        assert "x_train" in result
+        assert "y_test" not in result
+        assert "y_train" not in result
 
+    def test_preserves_original_variables(self, simple_dataset):
+        """Test that the original variables are still present in the output dataset."""
+        result = split_test_set(simple_dataset, filters={"cosmo_idx": [0, 1]})
+        assert "x" in result
+        assert "y" in result
 
-def test_split_test_set_missing_variable_raises(simple_dataset):
-    with pytest.raises(ValueError, match="not found"):
-        split_test_set(simple_dataset, filters={"cosmo_idx": [0]}, to_split=["z"])
-
-
-def test_split_test_set_custom_to_split(simple_dataset):
-    result = split_test_set(simple_dataset, filters={"cosmo_idx": [0, 1]}, to_split=["x"])
-    assert "x_test" in result
-    assert "x_train" in result
-    assert "y_test" not in result
-    assert "y_train" not in result
-
-
-def test_split_test_set_preserves_original_variables(simple_dataset):
-    result = split_test_set(simple_dataset, filters={"cosmo_idx": [0, 1]})
-    assert "x" in result
-    assert "y" in result
-
-# %% collect_mocks
+# %% collect_measurements
 
 @pytest.fixture()
 def mock_file_tree(tmp_path):
@@ -229,60 +240,63 @@ def mock_file_tree(tmp_path):
 
 GLOB_PATTERN = "c{cosmo_idx}_ph{phase_idx}/seed{seed}/hod{hod_idx}/power_spectrum_los_{los}.h5"
 
+class TestCollectMeasurements:
+    """Tests for the collect_measurements function."""
+    
+    def test_groups_by_index(self, mock_file_tree):
+        """Test that files are grouped by unique combinations of index values, ignoring specified indexes."""
+        groups, _ = collect_measurements(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
+        # 2*2 unique combinations of cosmo_idx and hod_idx, so 4 groups
+        assert len(groups) == 4
 
-def test_collect_mocks_groups_by_index(mock_file_tree):
-    groups, index_arrays = collect_mocks(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
-    # 2*2 unique combinations of cosmo_idx and hod_idx, so 4 groups
-    assert len(groups) == 4
+    def test_ignored_index_files_are_grouped(self, mock_file_tree):
+        """Test that files differing only in the ignored index (los) are grouped together."""
+        groups, _ = collect_measurements(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
+        # Each group should contain 2 files (los_x and los_y)
+        assert all(len(files) == 2 for files in groups.values())
 
+    def test_ignored_index_not_in_index_arrays(self, mock_file_tree):
+        """Test that the ignored index is not included in the returned index arrays."""
+        _, index_arrays = collect_measurements(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
+        assert "los" not in index_arrays
 
-def test_collect_mocks_ignored_index_files_are_grouped(mock_file_tree):
-    groups, _ = collect_mocks(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
-    # Each group should contain 2 files (los_x and los_y)
-    assert all(len(files) == 2 for files in groups.values())
+    def test_index_arrays_aligned(self, mock_file_tree):
+        """Test that the returned index arrays are aligned with the groups (same length and order)."""
+        _, index_arrays = collect_measurements(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
+        lengths = [len(v) for v in index_arrays.values()]
+        assert len(set(lengths)) == 1  # all same length
 
+    def test_correct_index_values(self, mock_file_tree):
+        """Test that the index arrays contain the correct unique values from the file paths."""
+        _, index_arrays = collect_measurements(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
+        assert set(index_arrays["cosmo_idx"]) == {"000", "001"}
+        assert set(index_arrays["hod_idx"]) == {"006", "008"}
 
-def test_collect_mocks_ignored_index_not_in_index_arrays(mock_file_tree):
-    _, index_arrays = collect_mocks(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
-    assert "los" not in index_arrays
+    def test_no_ignore_index(self, mock_file_tree):
+        """Test that if no indexes are ignored, each unique combination of all indexes is its own group."""
+        groups, index_arrays = collect_measurements(mock_file_tree, GLOB_PATTERN)
+        # Without ignoring 'los', each (cosmo, phase, seed, hod, los) combo is its own group
+        assert "los" in index_arrays
+        assert all(len(files) == 1 for files in groups.values())
 
+    def test_all_indexes_tracked(self, mock_file_tree):
+        """Test that all tracked indexes exist in the index array."""
+        _, index_arrays = collect_measurements(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
+        assert set(index_arrays.keys()) == {"cosmo_idx", "phase_idx", "seed", "hod_idx"}
 
-def test_collect_mocks_index_arrays_aligned(mock_file_tree):
-    _, index_arrays = collect_mocks(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
-    lengths = [len(v) for v in index_arrays.values()]
-    assert len(set(lengths)) == 1  # all same length
+    def test_empty_dir(self, tmp_path):
+        """Test that if the directory contains no matching files, the function returns empty groups and index arrays."""
+        groups, index_arrays = collect_measurements(tmp_path, GLOB_PATTERN, ignore_index=["los"])
+        assert len(groups) == 0
+        assert all(len(v) == 0 for v in index_arrays.values())
 
+    def test_sorted_files(self, mock_file_tree):
+        """Test that the files within each group are sorted (for consistent ordering)."""
+        groups, _ = collect_measurements(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
+        for files in groups.values():
+            assert files == sorted(files)
 
-def test_collect_mocks_correct_index_values(mock_file_tree):
-    _, index_arrays = collect_mocks(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
-    assert set(index_arrays["cosmo_idx"]) == {"000", "001"}
-    assert set(index_arrays["hod_idx"]) == {"006", "008"}
-
-def test_collect_mocks_no_ignore_index(mock_file_tree):
-    groups, index_arrays = collect_mocks(mock_file_tree, GLOB_PATTERN)
-    # Without ignoring 'los', each (cosmo, phase, seed, hod, los) combo is its own group
-    assert "los" in index_arrays
-    assert all(len(files) == 1 for files in groups.values())
-
-
-def test_collect_mocks_all_indexes_tracked(mock_file_tree):
-    _, index_arrays = collect_mocks(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
-    assert set(index_arrays.keys()) == {"cosmo_idx", "phase_idx", "seed", "hod_idx"}
-
-
-def test_collect_mocks_empty_dir(tmp_path):
-    groups, index_arrays = collect_mocks(tmp_path, GLOB_PATTERN, ignore_index=["los"])
-    assert len(groups) == 0
-    assert all(len(v) == 0 for v in index_arrays.values())
-
-
-def test_collect_mocks_sorted_files(mock_file_tree):
-    # Files within each group should be sorted
-    groups, _ = collect_mocks(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
-    for files in groups.values():
-        assert files == sorted(files)
-
-# %% compress_mocks
+# %% compress_measurements
 
 def _dummy_reader(files):
     """Returns a simple sentinel object (just the count of files)."""
@@ -295,129 +309,136 @@ def _dummy_postprocess(data, **kwargs):
     coords = {"feature": [0, 1]}
     return arr, coords
 
-def test_compress_mocks_sparse_grid_raises(tmp_path):
-    """Sparse grids (missing index combinations) should raise a ValueError."""
-    files = [
-        "c000_ph000/seed0/hod006/power_spectrum_los_x.h5",
-        "c001_ph000/seed0/hod008/power_spectrum_los_x.h5",  # c001/hod006 and c000/hod008 are missing
-    ]
-    for f in files:
-        p = tmp_path / f
-        p.parent.mkdir(parents=True, exist_ok=True)
-        p.touch()
+class TestCompressMeasurements:
+    """Tests for the compress_measurements function."""
+    
+    def test_sparse_grid_raises(self, tmp_path):
+        """Sparse grids (missing index combinations) should raise a ValueError."""
+        files = [
+            "c000_ph000/seed0/hod006/power_spectrum_los_x.h5",
+            "c001_ph000/seed0/hod008/power_spectrum_los_x.h5",  # c001/hod006 and c000/hod008 are missing
+        ]
+        for f in files:
+            p = tmp_path / f
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.touch()
 
-    groups, index_arrays = collect_mocks(tmp_path, GLOB_PATTERN, ignore_index=["los"])
-    with pytest.raises(ValueError, match="sparse"):
-        compress_mocks(groups, index_arrays, reader=_dummy_reader, postprocess=_dummy_postprocess)
+        groups, index_arrays = collect_measurements(tmp_path, GLOB_PATTERN, ignore_index=["los"])
+        with pytest.raises(ValueError, match="sparse"):
+            compress_measurements(groups, index_arrays, reader=_dummy_reader, postprocess=_dummy_postprocess)
 
-def test_compress_mocks_correct_shape(mock_file_tree):
-    groups, index_arrays = collect_mocks(mock_file_tree, GLOB_PATTERN, ignore_index=["los", "seed", "phase_idx"])
-    result = compress_mocks(groups, index_arrays, reader=_dummy_reader, postprocess=_dummy_postprocess)
-    # (n_hod=2, n_cosmo=2, n_features=2) with singleton dims dropped
-    assert result.shape == (2, 2, 2)
+    def test_correct_shape(self, mock_file_tree):
+        """Test that the output DataArray has the expected shape based on the number of unique index values and features."""
+        groups, index_arrays = collect_measurements(mock_file_tree, GLOB_PATTERN, ignore_index=["los", "seed", "phase_idx"])
+        result = compress_measurements(groups, index_arrays, reader=_dummy_reader, postprocess=_dummy_postprocess)
+        # (n_hod=2, n_cosmo=2, n_features=2) with singleton dims dropped
+        assert result.shape == (2, 2, 2)
 
+    def test_reader_called_once_per_group(self, mock_file_tree):
+        """Test that the reader function is called exactly once for each group of files, not once per file."""
+        groups, index_arrays = collect_measurements(mock_file_tree, GLOB_PATTERN, ignore_index=["los", "seed", "phase_idx"])
+        call_count = 0
 
-def test_compress_mocks_reader_called_once_per_group(mock_file_tree):
-    groups, index_arrays = collect_mocks(mock_file_tree, GLOB_PATTERN, ignore_index=["los", "seed", "phase_idx"])
-    call_count = 0
+        def counting_reader(files):
+            nonlocal call_count
+            call_count += 1
+            return len(files)
 
-    def counting_reader(files):
-        nonlocal call_count
-        call_count += 1
-        return len(files)
+        compress_measurements(groups, index_arrays, reader=counting_reader, postprocess=_dummy_postprocess)
+        assert call_count == len(groups)
 
-    compress_mocks(groups, index_arrays, reader=counting_reader, postprocess=_dummy_postprocess)
-    assert call_count == len(groups)
+    def test_output_is_dataarray(self, mock_file_tree):
+        """Test that the output of compress_measurements is an xarray DataArray."""
+        groups, index_arrays = collect_measurements(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
+        result = compress_measurements(
+            groups, index_arrays,
+            reader=_dummy_reader,
+            postprocess=_dummy_postprocess,
+        )
+        assert isinstance(result, xarray.DataArray)
 
-def test_compress_mocks_output_is_dataarray(mock_file_tree):
-    groups, index_arrays = collect_mocks(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
-    result = compress_mocks(
-        groups, index_arrays,
-        reader=_dummy_reader,
-        postprocess=_dummy_postprocess,
-    )
-    assert isinstance(result, xarray.DataArray)
+    def test_sample_dims_in_coords(self, mock_file_tree):
+        """Test that the sample index arrays (e.g. cosmo_idx, hod_idx) are included in the output DataArray's coordinates."""
+        groups, index_arrays = collect_measurements(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
+        result = compress_measurements(
+            groups, index_arrays,
+            reader=_dummy_reader,
+            postprocess=_dummy_postprocess,
+        )
+        for idx in ["cosmo_idx", "hod_idx"]:
+            assert idx in result.coords
 
+    def test_feature_dims_in_coords(self, mock_file_tree):
+        """Test that the feature dimension from the postprocess output is included in the coordinates."""
+        groups, index_arrays = collect_measurements(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
+        result = compress_measurements(
+            groups, index_arrays,
+            reader=_dummy_reader,
+            postprocess=_dummy_postprocess,
+        )
+        assert "feature" in result.coords
 
-def test_compress_mocks_sample_dims_in_coords(mock_file_tree):
-    groups, index_arrays = collect_mocks(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
-    result = compress_mocks(
-        groups, index_arrays,
-        reader=_dummy_reader,
-        postprocess=_dummy_postprocess,
-    )
-    for idx in ["cosmo_idx", "hod_idx"]:
-        assert idx in result.coords
+    def test_attrs(self, mock_file_tree):
+        """Test that the output DataArray has a 'sample' attribute containing the sample index arrays, and a 'features' attribute describing the features."""
+        groups, index_arrays = collect_measurements(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
+        result = compress_measurements(
+            groups, index_arrays,
+            reader=_dummy_reader,
+            postprocess=_dummy_postprocess,
+        )
+        assert "sample" in result.attrs
+        assert "features" in result.attrs
 
+    def test_with_reindex(self, mock_file_tree):
+        """Test that when reindexing is applied, the sample coordinates are re-indexed to contiguous integers starting from 0 within each group."""
+        groups, index_arrays = collect_measurements(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
+        result = compress_measurements(
+            groups, index_arrays,
+            reindex=["hod_idx"],
+            reindex_group_by=["cosmo_idx"],
+            reader=_dummy_reader,
+            postprocess=_dummy_postprocess,
+        )
+        # After reindexing, hod_idx coords should be contiguous integers from 0
+        hod_coords = result.coords["hod_idx"].values
+        assert set(hod_coords) == set(range(len(hod_coords)))
 
-def test_compress_mocks_feature_dims_in_coords(mock_file_tree):
-    groups, index_arrays = collect_mocks(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
-    result = compress_mocks(
-        groups, index_arrays,
-        reader=_dummy_reader,
-        postprocess=_dummy_postprocess,
-    )
-    assert "feature" in result.coords
+    def test_drop_singleton_dims(self, mock_file_tree):
+        """Test that when drop_singleton_dims=True, any sample index dimensions that have only one unique value are dropped from the coordinates and attributes."""
+        groups, index_arrays = collect_measurements(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
+        result = compress_measurements(
+            groups, index_arrays,
+            drop_singleton_dims=True,
+            reader=_dummy_reader,
+            postprocess=_dummy_postprocess,
+        )
+        assert all(s > 1 for s in result.shape)
+        assert "phase_idx" not in result.coords
+        assert "seed" not in result.coords
+        assert "phase_idx" not in result.attrs["sample"]
+        assert "seed" not in result.attrs["sample"]
 
+    def test_no_drop_singleton_dims(self, mock_file_tree):
+        """Test that when drop_singleton_dims=False, sample index dimensions that have only one unique value are retained in the coordinates and attributes."""
+        groups, index_arrays = collect_measurements(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
+        result = compress_measurements(
+            groups, index_arrays,
+            drop_singleton_dims=False,
+            reader=_dummy_reader,
+            postprocess=_dummy_postprocess,
+        )
+        # Singleton dims (phase, seed) should still be present
+        assert "phase_idx" in result.coords
+        assert "seed" in result.coords
+        assert "phase_idx" in result.attrs["sample"]
+        assert "seed" in result.attrs["sample"]
 
-def test_compress_mocks_attrs(mock_file_tree):
-    groups, index_arrays = collect_mocks(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
-    result = compress_mocks(
-        groups, index_arrays,
-        reader=_dummy_reader,
-        postprocess=_dummy_postprocess,
-    )
-    assert "sample" in result.attrs
-    assert "features" in result.attrs
-
-
-def test_compress_mocks_with_reindex(mock_file_tree):
-    groups, index_arrays = collect_mocks(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
-    result = compress_mocks(
-        groups, index_arrays,
-        reindex=["hod_idx"],
-        reindex_group_by=["cosmo_idx"],
-        reader=_dummy_reader,
-        postprocess=_dummy_postprocess,
-    )
-    # After reindexing, hod_idx coords should be contiguous integers from 0
-    hod_coords = result.coords["hod_idx"].values
-    assert set(hod_coords) == set(range(len(hod_coords)))
-
-
-def test_compress_mocks_drop_singleton_dims(mock_file_tree):
-    groups, index_arrays = collect_mocks(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
-    result = compress_mocks(
-        groups, index_arrays,
-        drop_singleton_dims=True,
-        reader=_dummy_reader,
-        postprocess=_dummy_postprocess,
-    )
-    assert all(s > 1 for s in result.shape)
-    assert "phase_idx" not in result.coords
-    assert "seed" not in result.coords
-    assert "phase_idx" not in result.attrs["sample"]
-    assert "seed" not in result.attrs["sample"]
-
-def test_compress_mocks_no_drop_singleton_dims(mock_file_tree):
-    groups, index_arrays = collect_mocks(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
-    result = compress_mocks(
-        groups, index_arrays,
-        drop_singleton_dims=False,
-        reader=_dummy_reader,
-        postprocess=_dummy_postprocess,
-    )
-    # Singleton dims (phase, seed) should still be present
-    assert "phase_idx" in result.coords
-    assert "seed" in result.coords
-    assert "phase_idx" in result.attrs["sample"]
-    assert "seed" in result.attrs["sample"]
-
-def test_compress_mocks_data_values(mock_file_tree):
-    groups, index_arrays = collect_mocks(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
-    result = compress_mocks(
-        groups, index_arrays,
-        reader=_dummy_reader,
-        postprocess=_dummy_postprocess,
-    )
-    np.testing.assert_array_equal(result.values, np.ones(result.shape))
+    def test_data_values(self, mock_file_tree):
+        """Test that the data values in the output DataArray match the expected output from the reader and postprocess functions."""
+        groups, index_arrays = collect_measurements(mock_file_tree, GLOB_PATTERN, ignore_index=["los"])
+        result = compress_measurements(
+            groups, index_arrays,
+            reader=_dummy_reader,
+            postprocess=_dummy_postprocess,
+        )
+        np.testing.assert_array_equal(result.values, np.ones(result.shape))


### PR DESCRIPTION
Following #184, I introduce a new utils file that should lead to the deprecation of the Observables compression methods.

By using regex on glob search, this PR allows us to move the compression functions outside of the scope of each filetype and project

This files introduces 2 main methods: 
- `collect_mocks` to extract filenames from a glob pattern and a root directory, returns indices for each group of files found from the pattern. e.g. for `c{cosmo_idx}_ph{phase_idx}/hod{hod_idx}/tpcf_los_{los}.npy`, will return all filenames grouped by cosmo + phase + hod + los indices.
- `compress_mocks` to compress all mocks found by the previous method in one `DataArray`. It has a `reader` method and a `filter` method in input to not depend on the file type of the manipulation on those. The reader reads and merges each group of files in one object, the filter handles these objects and returns an array and a dictionary containing the _dimensions_ of this array (passed to `xarray`)

> [!NOTE]
> I'm not sure of the format of the groups, at the moment it's a dict with a tuple of indices as the key, and a list of filenames as the values, but it can be a bit complicated to handle. We could find an easier solution ?

I also added 2 temporary methods (`compress_x` and `compress_data`), adapted from the BGS file compression - that could eventually be moved somewhere else.
**TBD: Do we want those methods in acm or can we move those in the scripts ?**