### PR TITLE
Fix double application of box offset in voxel_position

### DIFF
--- a/acm/estimators/galaxy_clustering/jaxel_voids.py
+++ b/acm/estimators/galaxy_clustering/jaxel_voids.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 import time
 from collections.abc import Iterator

--- a/acm/estimators/galaxy_clustering/jaxel_voids.py
+++ b/acm/estimators/galaxy_clustering/jaxel_voids.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import time
 from collections.abc import Iterator
@@ -535,11 +537,6 @@ class JaxelVoids(BaseEstimator):
         xpos = xi * boxsize[0] / nmesh[0]
         ypos = yi * boxsize[1] / nmesh[1]
         zpos = zi * boxsize[2] / nmesh[2]
-
-        if self.has_randoms:
-            xpos += boxcenter[0] - boxsize[0] / 2.0
-            ypos += boxcenter[1] - boxsize[1] / 2.0
-            zpos += boxcenter[2] - boxsize[2] / 2.0
 
         offset = boxcenter - boxsize / 2.0
         xpos += offset[0]


### PR DESCRIPTION
Fixes a coordinate centering bug in voxel_position() from jaxel_voids.py where the offset (boxcenter - boxsize/2) was applied twice in workflows using random catalogs (has_randoms=True), causing void centers to be offset from true density minima and corrupting void–galaxy cross-correlations. The transformation from mesh to physical coordinates is now applied exactly once, independent of geometry.

Also added from __future__ import annotations (PEP 563) to defer evaluation of type hints, preventing TypeError at import time from union types like str | Path | None.