### PR TITLE
[Hotfix] ty update & pyproject rework (#251)

### DIFF
--- a/.github/workflows/ci-format-lint-test.yml
+++ b/.github/workflows/ci-format-lint-test.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Installation package with editable mode
         run: |
           python -m pip install --upgrade pip
-          pip install -e .[testing,sunbird,cosmodesi,jaxpower]
+          pip install -e .[testing]
 
       - name: Process tests
         run: |

--- a/acm/estimators/galaxy_clustering/jaxel_voids.py
+++ b/acm/estimators/galaxy_clustering/jaxel_voids.py
@@ -290,7 +290,7 @@ class JaxelVoids(BaseEstimator):
     def save(
         self,
         filename: str | Path,
-        data: type[BaseTwoPointEstimator] | None = None,
+        data: BaseTwoPointEstimator | None = None,
         data_type: str = "catalog",
         attrs: dict | None = None,
     ) -> None:

--- a/acm/estimators/galaxy_clustering/jaxel_voids.py
+++ b/acm/estimators/galaxy_clustering/jaxel_voids.py
@@ -16,6 +16,7 @@ from lsstypes.external import from_pycorr
 from matplotlib import animation, cm
 from matplotlib.figure import Figure
 from pycorr import TwoPointCorrelationFunction
+from pycorr.twopoint_estimator import BaseTwoPointEstimator
 
 from acm.utils.plotting import set_plot_style
 
@@ -245,7 +246,7 @@ class JaxelVoids(BaseEstimator):
 
     def save_correlations(
         self,
-        correlation: TwoPointCorrelationFunction,
+        correlation: type[BaseTwoPointEstimator],
         filename: str | Path,
         attrs: dict | None = None,
     ) -> None:
@@ -253,7 +254,7 @@ class JaxelVoids(BaseEstimator):
 
         Parameters
         ----------
-        correlation : TwoPointCorrelationFunction
+        correlation : BaseTwoPointEstimator
             Correlation object to save.
         filename : str or Path
             Output filename.
@@ -279,7 +280,7 @@ class JaxelVoids(BaseEstimator):
                 corr_leaf.attrs.update(base_attrs)
             corr_leaf.write(path)
         elif path.suffix == ".npy":
-            np.save(path, correlation)
+            np.save(path, correlation)  # ty:ignore[invalid-argument-type]
         else:
             raise ValueError(
                 f"Unrecognized file extension '{path.suffix}' for file: {path}. "
@@ -289,7 +290,7 @@ class JaxelVoids(BaseEstimator):
     def save(
         self,
         filename: str | Path,
-        data: TwoPointCorrelationFunction | None = None,
+        data: type[BaseTwoPointEstimator] | None = None,
         data_type: str = "catalog",
         attrs: dict | None = None,
     ) -> None:
@@ -299,7 +300,7 @@ class JaxelVoids(BaseEstimator):
         ----------
         filename : str or Path
             Output filename.
-        data : TwoPointCorrelationFunction, optional
+        data : BaseTwoPointEstimator, optional
             Data payload to save when ``data_type='correlation'``. If omitted,
             ``self._void_data_correlation`` is used.
         data_type : {'catalog', 'correlation'}, default='catalog'
@@ -552,7 +553,7 @@ class JaxelVoids(BaseEstimator):
         data_positions: npt.NDArray,
         save_fn: str | Path | None = None,
         **kwargs,
-    ) -> TwoPointCorrelationFunction:
+    ) -> type[BaseTwoPointEstimator]:
         """Compute the void-data two-point correlation function.
 
         Parameters
@@ -567,7 +568,7 @@ class JaxelVoids(BaseEstimator):
 
         Returns
         -------
-        TwoPointCorrelationFunction
+        type[BaseTwoPointEstimator]
             Configured pycorr object containing measured correlation statistics.
         """
         if self.has_randoms:

--- a/acm/estimators/galaxy_clustering/jaxel_voids.py
+++ b/acm/estimators/galaxy_clustering/jaxel_voids.py
@@ -568,7 +568,7 @@ class JaxelVoids(BaseEstimator):
 
         Returns
         -------
-        type[BaseTwoPointEstimator]
+        BaseTwoPointEstimator
             Configured pycorr object containing measured correlation statistics.
         """
         if self.has_randoms:

--- a/acm/estimators/galaxy_clustering/jaxel_voids.py
+++ b/acm/estimators/galaxy_clustering/jaxel_voids.py
@@ -553,7 +553,7 @@ class JaxelVoids(BaseEstimator):
         data_positions: npt.NDArray,
         save_fn: str | Path | None = None,
         **kwargs,
-    ) -> type[BaseTwoPointEstimator]:
+    ) -> BaseTwoPointEstimator:
         """Compute the void-data two-point correlation function.
 
         Parameters

--- a/acm/estimators/galaxy_clustering/jaxel_voids.py
+++ b/acm/estimators/galaxy_clustering/jaxel_voids.py
@@ -246,7 +246,7 @@ class JaxelVoids(BaseEstimator):
 
     def save_correlations(
         self,
-        correlation: type[BaseTwoPointEstimator],
+        correlation: BaseTwoPointEstimator,
         filename: str | Path,
         attrs: dict | None = None,
     ) -> None:

--- a/acm/estimators/galaxy_clustering/pydive.py
+++ b/acm/estimators/galaxy_clustering/pydive.py
@@ -436,7 +436,7 @@ class DTVoid(BaseEstimator):
         colors = plt.rcParams["axes.prop_cycle"].by_key()["color"]
         fig, ax = plt.subplots(figsize=(4, 4))
         for i in range(len(self.samples)):
-            s, multipoles = self._sample_data_correlation[i]( # ty: ignore[call-non-callable]
+            s, multipoles = self._sample_data_correlation[i](  # ty: ignore[call-non-callable]
                 ells=(0, 2, 4), return_sep=True
             )
             ax.plot(
@@ -462,7 +462,7 @@ class DTVoid(BaseEstimator):
         """Plot the correlation function of the sampled voids."""
         fig, ax = plt.subplots(figsize=(4, 4))
         for i in range(len(self.samples)):
-            s, multipoles = self._sample_correlation[i](ells=(0, 2, 4), return_sep=True) # ty: ignore[call-non-callable]
+            s, multipoles = self._sample_correlation[i](ells=(0, 2, 4), return_sep=True)  # ty: ignore[call-non-callable]
             ax.plot(s, s**2 * multipoles[ell // 2], lw=2.0, label=rf"${{\rm DTS}}_{i}$")
         ax.set_xlabel(r"$s\, [h^{-1}{\rm Mpc}]$", fontsize=15)
         ax.set_ylabel(r"$s^2 \xi_\ell\, [h^{-2}{\rm Mpc^2}](s)$", fontsize=15)

--- a/acm/estimators/galaxy_clustering/pydive.py
+++ b/acm/estimators/galaxy_clustering/pydive.py
@@ -6,6 +6,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from pycorr import TwoPointCorrelationFunction
+from pycorr.twopoint_estimator import BaseTwoPointEstimator
 from pypower import CatalogFFTPower
 
 from acm.utils.plotting import set_plot_style
@@ -183,7 +184,7 @@ class DTVoid(BaseEstimator):
 
     def sample_data_correlation(
         self, data_positions: np.ndarray, **kwargs
-    ) -> list[TwoPointCorrelationFunction]:
+    ) -> list[BaseTwoPointEstimator]:
         """
         Compute the cross-correlation function between the density field samples and the data.
 
@@ -196,7 +197,7 @@ class DTVoid(BaseEstimator):
 
         Returns
         -------
-        _sample_data_correlation: list[TwoPointCorrelationFunction]
+        _sample_data_correlation: list[BaseTwoPointEstimator]
             List of cross-correlation functions between samples and data.
         """
         nsplits = kwargs.pop("nsplits", 1)
@@ -245,7 +246,7 @@ class DTVoid(BaseEstimator):
 
         return self._sample_data_correlation
 
-    def sample_correlation(self, **kwargs) -> list[TwoPointCorrelationFunction]:
+    def sample_correlation(self, **kwargs) -> list[BaseTwoPointEstimator]:
         """
         Compute the auto-correlation function of the density field samples.
 
@@ -256,7 +257,7 @@ class DTVoid(BaseEstimator):
 
         Returns
         -------
-        _sample_correlation: list[TwoPointCorrelationFunction]
+        _sample_correlation: list[BaseTwoPointEstimator]
             List of auto-correlation functions of samples.
         """
         if self.has_randoms:
@@ -435,7 +436,7 @@ class DTVoid(BaseEstimator):
         colors = plt.rcParams["axes.prop_cycle"].by_key()["color"]
         fig, ax = plt.subplots(figsize=(4, 4))
         for i in range(len(self.samples)):
-            s, multipoles = self._sample_data_correlation[i](
+            s, multipoles = self._sample_data_correlation[i]( # ty: ignore[call-non-callable]
                 ells=(0, 2, 4), return_sep=True
             )
             ax.plot(
@@ -461,7 +462,7 @@ class DTVoid(BaseEstimator):
         """Plot the correlation function of the sampled voids."""
         fig, ax = plt.subplots(figsize=(4, 4))
         for i in range(len(self.samples)):
-            s, multipoles = self._sample_correlation[i](ells=(0, 2, 4), return_sep=True)
+            s, multipoles = self._sample_correlation[i](ells=(0, 2, 4), return_sep=True) # ty: ignore[call-non-callable]
             ax.plot(s, s**2 * multipoles[ell // 2], lw=2.0, label=rf"${{\rm DTS}}_{i}$")
         ax.set_xlabel(r"$s\, [h^{-1}{\rm Mpc}]$", fontsize=15)
         ax.set_ylabel(r"$s^2 \xi_\ell\, [h^{-2}{\rm Mpc^2}](s)$", fontsize=15)

--- a/acm/estimators/galaxy_clustering/voxel_voids.py
+++ b/acm/estimators/galaxy_clustering/voxel_voids.py
@@ -12,6 +12,7 @@ import numpy.typing as npt
 from matplotlib import cm
 from matplotlib.figure import Figure
 from pycorr import TwoPointCorrelationFunction
+from pycorr.twopoint_estimator import BaseTwoPointEstimator
 
 from acm.utils.plotting import set_plot_style
 
@@ -312,7 +313,7 @@ class VoxelVoids(BaseEstimator):
         self,
         data_positions: npt.NDArray,
         **kwargs,
-    ) -> TwoPointCorrelationFunction:
+    ) -> BaseTwoPointEstimator:
         """
         Compute the cross-correlation function between the voids and the data.
 

--- a/acm/hod/parameters.py
+++ b/acm/hod/parameters.py
@@ -80,7 +80,7 @@ class HODLatinHypercube:
         split_params = {}
         for i, cosmo in enumerate(cosmos):
             split = [
-                np.array_split(self.params[key], len(cosmos))[i] for key in self.params
+                np.array_split(np.asarray(self.params[key]), len(cosmos))[i] for key in self.params
             ]
             split_params[f"c{cosmo:03}"] = {
                 key: list(split[i]) for i, key in enumerate(self.params)
@@ -109,7 +109,7 @@ class HODLatinHypercube:
         """
         for key, hod in self.params.items():
             n_hod = len(
-                hod[next(iter(hod))]
+                hod[next(iter(hod))]  # ty:ignore[invalid-argument-type]
             )  # number of HOD samples for this cosmology
             cosmo = {
                 k: [v] * n_hod for k, v in cosmo_params[key].items()

--- a/acm/observables/base.py
+++ b/acm/observables/base.py
@@ -775,7 +775,7 @@ class Observable:
             )
 
         cov_y = self.flatten_output(
-            cov_y, # ty:ignore[invalid-argument-type]
+            cov_y,  # ty:ignore[invalid-argument-type]
             flat_output_dims=2,
             unstack=False,
         )  # No unstacking to avoid NaN

--- a/acm/observables/base.py
+++ b/acm/observables/base.py
@@ -775,9 +775,9 @@ class Observable:
             )
 
         cov_y = self.flatten_output(
-            cov_y,
+            cov_y, # ty:ignore[invalid-argument-type]
             flat_output_dims=2,
-            unstack=False,  # ty:ignore[invalid-argument-type]
+            unstack=False,
         )  # No unstacking to avoid NaN
         cov_y = cov_y.values
 

--- a/acm/observables/emc/projected_tpcf_module.py
+++ b/acm/observables/emc/projected_tpcf_module.py
@@ -149,7 +149,7 @@ class ProjectedGalaxyCorrelationFunction(BaseObservableEMC):
             hods[cosmo_idx] = [int(f.stem.split("hod")[-1]) for f in filenames]
             logger.info(f"Number of HODs: {len(hods[cosmo_idx])}")
             for filename in filenames:
-                data = TwoPointCorrelationFunction.load(filename) # ty:ignore[unresolved-attribute]
+                data = TwoPointCorrelationFunction.load(filename)  # ty:ignore[unresolved-attribute]
                 r_p, w_p = data(pimax=None, return_sep=True)
                 y.append(w_p)
 

--- a/acm/observables/emc/projected_tpcf_module.py
+++ b/acm/observables/emc/projected_tpcf_module.py
@@ -58,7 +58,7 @@ class ProjectedGalaxyCorrelationFunction(BaseObservableEMC):
 
         y = []
         for data_fn in data_fns:
-            data = TwoPointCorrelationFunction.load(data_fn)
+            data = TwoPointCorrelationFunction.load(data_fn)  # ty:ignore[unresolved-attribute]
             r_p, w_p = data(pimax=None, return_sep=True)
             y.append(w_p)
         y = np.array(y)
@@ -149,7 +149,7 @@ class ProjectedGalaxyCorrelationFunction(BaseObservableEMC):
             hods[cosmo_idx] = [int(f.stem.split("hod")[-1]) for f in filenames]
             logger.info(f"Number of HODs: {len(hods[cosmo_idx])}")
             for filename in filenames:
-                data = TwoPointCorrelationFunction.load(filename)
+                data = TwoPointCorrelationFunction.load(filename) # ty:ignore[unresolved-attribute]
                 r_p, w_p = data(pimax=None, return_sep=True)
                 y.append(w_p)
 

--- a/acm/observables/emc/tpcf_module.py
+++ b/acm/observables/emc/tpcf_module.py
@@ -66,7 +66,7 @@ class GalaxyCorrelationFunctionMultipoles(BaseObservableEMC):
 
         y = []
         for data_fn in data_fns:
-            data = TwoPointCorrelationFunction.load(data_fn)[::rebin] # ty:ignore[unresolved-attribute]
+            data = TwoPointCorrelationFunction.load(data_fn)[::rebin]  # ty:ignore[unresolved-attribute]
             s, multipoles = data(ells=ells, return_sep=True)
             y.append(np.concatenate(multipoles))
         y = np.array(y)
@@ -161,7 +161,7 @@ class GalaxyCorrelationFunctionMultipoles(BaseObservableEMC):
             data_dir = base_dir + f"c{cosmo_idx:03d}_ph{phase:03d}/seed{seed}/"
             for hod_idx in range(n_hod):
                 data_fn = f"{data_dir}/tpcf_hod{hod_idx:03}.npy"  # NOTE: File name format hardcoded !
-                data = TwoPointCorrelationFunction.load(data_fn)[::rebin] # ty:ignore[unresolved-attribute]
+                data = TwoPointCorrelationFunction.load(data_fn)[::rebin]  # ty:ignore[unresolved-attribute]
                 s, multipoles = data(ells=ells, return_sep=True)
                 y.append(np.concatenate(multipoles))
         y = np.array(y)
@@ -243,7 +243,7 @@ class GalaxyCorrelationFunctionMultipoles(BaseObservableEMC):
                 data_fn = (
                     Path(data_dir) / f"tpcf_hod{hod:03}.npy"
                 )  # NOTE: File name format hardcoded !
-                data = TwoPointCorrelationFunction.load(data_fn)[::rebin] # ty:ignore[unresolved-attribute]
+                data = TwoPointCorrelationFunction.load(data_fn)[::rebin]  # ty:ignore[unresolved-attribute]
                 multipoles = data(ells=ells)
                 multipoles_hods.append(multipoles)
             multipoles_hods = np.array(multipoles_hods).mean(axis=0)
@@ -256,7 +256,7 @@ class GalaxyCorrelationFunctionMultipoles(BaseObservableEMC):
             data_fn = (
                 Path(data_dir) / f"tpcf_hod{hod:03}.npy"
             )  # NOTE: File name format hardcoded !
-            data = TwoPointCorrelationFunction.load(data_fn)[::4] # ty:ignore[unresolved-attribute]
+            data = TwoPointCorrelationFunction.load(data_fn)[::4]  # ty:ignore[unresolved-attribute]
             multipoles = data(ells=ells)
             multipoles_ph0.append(multipoles)
         multipoles_ph0 = np.array(multipoles_ph0).mean(axis=0)

--- a/acm/observables/emc/tpcf_module.py
+++ b/acm/observables/emc/tpcf_module.py
@@ -66,7 +66,7 @@ class GalaxyCorrelationFunctionMultipoles(BaseObservableEMC):
 
         y = []
         for data_fn in data_fns:
-            data = TwoPointCorrelationFunction.load(data_fn)[::rebin]
+            data = TwoPointCorrelationFunction.load(data_fn)[::rebin] # ty:ignore[unresolved-attribute]
             s, multipoles = data(ells=ells, return_sep=True)
             y.append(np.concatenate(multipoles))
         y = np.array(y)
@@ -161,7 +161,7 @@ class GalaxyCorrelationFunctionMultipoles(BaseObservableEMC):
             data_dir = base_dir + f"c{cosmo_idx:03d}_ph{phase:03d}/seed{seed}/"
             for hod_idx in range(n_hod):
                 data_fn = f"{data_dir}/tpcf_hod{hod_idx:03}.npy"  # NOTE: File name format hardcoded !
-                data = TwoPointCorrelationFunction.load(data_fn)[::rebin]
+                data = TwoPointCorrelationFunction.load(data_fn)[::rebin] # ty:ignore[unresolved-attribute]
                 s, multipoles = data(ells=ells, return_sep=True)
                 y.append(np.concatenate(multipoles))
         y = np.array(y)
@@ -243,7 +243,7 @@ class GalaxyCorrelationFunctionMultipoles(BaseObservableEMC):
                 data_fn = (
                     Path(data_dir) / f"tpcf_hod{hod:03}.npy"
                 )  # NOTE: File name format hardcoded !
-                data = TwoPointCorrelationFunction.load(data_fn)[::rebin]
+                data = TwoPointCorrelationFunction.load(data_fn)[::rebin] # ty:ignore[unresolved-attribute]
                 multipoles = data(ells=ells)
                 multipoles_hods.append(multipoles)
             multipoles_hods = np.array(multipoles_hods).mean(axis=0)
@@ -256,7 +256,7 @@ class GalaxyCorrelationFunctionMultipoles(BaseObservableEMC):
             data_fn = (
                 Path(data_dir) / f"tpcf_hod{hod:03}.npy"
             )  # NOTE: File name format hardcoded !
-            data = TwoPointCorrelationFunction.load(data_fn)[::4]
+            data = TwoPointCorrelationFunction.load(data_fn)[::4] # ty:ignore[unresolved-attribute]
             multipoles = data(ells=ells)
             multipoles_ph0.append(multipoles)
         multipoles_ph0 = np.array(multipoles_ph0).mean(axis=0)

--- a/acm/observables/emc/versus_module.py
+++ b/acm/observables/emc/versus_module.py
@@ -386,7 +386,7 @@ class BaseVERSUSCorrelationFunctionMultipoles(BaseObservableEMC):
 
         y = []
         for data_fn in data_fns:
-            data = TwoPointCorrelationFunction.load(data_fn)[::rebin]
+            data = TwoPointCorrelationFunction.load(data_fn)[::rebin] # ty:ignore[unresolved-attribute]
             s, multipoles = data(ells=ells, return_sep=True)
             y.append(np.concatenate(multipoles))
         y = np.array(y)
@@ -484,7 +484,7 @@ class BaseVERSUSCorrelationFunctionMultipoles(BaseObservableEMC):
             handle = f"c{cosmo_idx:03d}_ph{phase:03d}/seed{seed}/{stat_name}_c{cosmo_idx:03d}_hod*.npy"
             filenames = sorted(base_dir.glob(handle))[:n_hod]
             for filename in filenames:
-                data = TwoPointCorrelationFunction.load(filename)[::rebin]
+                data = TwoPointCorrelationFunction.load(filename)[::rebin] # ty:ignore[unresolved-attribute]
                 s, multipoles = data(ells=ells, return_sep=True)
                 y.append(np.concatenate(multipoles))
         y = np.array(y)

--- a/acm/observables/emc/versus_module.py
+++ b/acm/observables/emc/versus_module.py
@@ -386,7 +386,7 @@ class BaseVERSUSCorrelationFunctionMultipoles(BaseObservableEMC):
 
         y = []
         for data_fn in data_fns:
-            data = TwoPointCorrelationFunction.load(data_fn)[::rebin] # ty:ignore[unresolved-attribute]
+            data = TwoPointCorrelationFunction.load(data_fn)[::rebin]  # ty:ignore[unresolved-attribute]
             s, multipoles = data(ells=ells, return_sep=True)
             y.append(np.concatenate(multipoles))
         y = np.array(y)
@@ -484,7 +484,7 @@ class BaseVERSUSCorrelationFunctionMultipoles(BaseObservableEMC):
             handle = f"c{cosmo_idx:03d}_ph{phase:03d}/seed{seed}/{stat_name}_c{cosmo_idx:03d}_hod*.npy"
             filenames = sorted(base_dir.glob(handle))[:n_hod]
             for filename in filenames:
-                data = TwoPointCorrelationFunction.load(filename)[::rebin] # ty:ignore[unresolved-attribute]
+                data = TwoPointCorrelationFunction.load(filename)[::rebin]  # ty:ignore[unresolved-attribute]
                 s, multipoles = data(ells=ells, return_sep=True)
                 y.append(np.concatenate(multipoles))
         y = np.array(y)

--- a/acm/utils/abacus.py
+++ b/acm/utils/abacus.py
@@ -73,15 +73,15 @@ def get_abacus_phases(
     """
     phase_dir = Path(phase_dir)  # Ensure phase_dir is a Path object
     
-    glob_pattern = f"AbacusSummit_small_c{cosmo:03d}_ph*/**/z{z:.3f}/"
-    abacus_fns = sorted(glob.glob(glob_pattern, root_dir=phase_dir))
+    glob_pattern = f"AbacusSummit_small_c{cosmo:03d}_ph*/*/z{z:.3f}/"
+    abacus_fns = sorted(phase_dir.glob(glob_pattern))
     
     z_str = f"{z:.3f}".replace('.', '\.')  # Convert z to a string suitable for regex
     re_pattern = re.compile(f"AbacusSummit_small_c{cosmo:03d}_ph(?P<phase>\d+)\/.+\/z{z_str}")
     
     phases = []
     for f in abacus_fns:
-        match = re_pattern.search(f)
+        match = re_pattern.search(str(f))
         if match:
             phases.append(int(match.group("phase")))
         else:

--- a/acm/utils/abacus.py
+++ b/acm/utils/abacus.py
@@ -1,7 +1,11 @@
+import re
+import glob
+import logging
 from pathlib import Path
 
 import pandas as pd
 
+logger = logging.getLogger(__name__)
 
 def load_abacus_cosmologies(
     filename: str,
@@ -43,9 +47,10 @@ def load_abacus_cosmologies(
         cosmo_params = cosmo_params.rename(columns=mapping)
     return cosmo_params.to_dict(orient="index")
 
-
 def get_abacus_phases(
-    phase_dir: str | Path, z: float, cosmo: int = 0
+    phase_dir: str | Path, 
+    z: float, 
+    cosmo: int = 0,
 ) -> tuple[list[Path], list[int]]:
     """
     Find the simulation phases for a given redshift.
@@ -67,10 +72,20 @@ def get_abacus_phases(
         A tuple containing a list of file paths and a list of phase indices.
     """
     phase_dir = Path(phase_dir)  # Ensure phase_dir is a Path object
+    
     glob_pattern = f"AbacusSummit_small_c{cosmo:03d}_ph*/**/z{z:.3f}/"
-    abacus_fns = sorted(phase_dir.glob(glob_pattern))
-    phases = [
-        int(Path(f).relative_to(phase_dir).parts[0].split("_")[-1].lstrip("ph"))
-        for f in abacus_fns
-    ]
-    return abacus_fns, phases
+    abacus_fns = sorted(glob.glob(glob_pattern, root_dir=phase_dir))
+    
+    z_str = f"{z:.3f}".replace('.', '\.')  # Convert z to a string suitable for regex
+    re_pattern = re.compile(f"AbacusSummit_small_c{cosmo:03d}_ph(?P<phase>\d+)\/.+\/z{z_str}")
+    
+    phases = []
+    for f in abacus_fns:
+        match = re_pattern.search(f)
+        if match:
+            phases.append(int(match.group("phase")))
+        else:
+            logger.warning(f"File {f} does not match the expected pattern and will be skipped.")
+    
+    fns = [Path(phase_dir) / fn for fn in abacus_fns]
+    return fns, phases

--- a/acm/utils/abacus.py
+++ b/acm/utils/abacus.py
@@ -1,11 +1,11 @@
-import re
-import glob
 import logging
+import re
 from pathlib import Path
 
 import pandas as pd
 
 logger = logging.getLogger(__name__)
+
 
 def load_abacus_cosmologies(
     filename: str,
@@ -47,9 +47,10 @@ def load_abacus_cosmologies(
         cosmo_params = cosmo_params.rename(columns=mapping)
     return cosmo_params.to_dict(orient="index")
 
+
 def get_abacus_phases(
-    phase_dir: str | Path, 
-    z: float, 
+    phase_dir: str | Path,
+    z: float,
     cosmo: int = 0,
 ) -> tuple[list[Path], list[int]]:
     """
@@ -72,20 +73,24 @@ def get_abacus_phases(
         A tuple containing a list of file paths and a list of phase indices.
     """
     phase_dir = Path(phase_dir)  # Ensure phase_dir is a Path object
-    
+
     glob_pattern = f"AbacusSummit_small_c{cosmo:03d}_ph*/*/z{z:.3f}/"
     abacus_fns = sorted(phase_dir.glob(glob_pattern))
-    
-    z_str = f"{z:.3f}".replace('.', '\.')  # Convert z to a string suitable for regex
-    re_pattern = re.compile(f"AbacusSummit_small_c{cosmo:03d}_ph(?P<phase>\d+)\/.+\/z{z_str}")
-    
+
+    z_str = f"{z:.3f}".replace(".", r"\.")  # Convert z to a string suitable for regex
+    re_pattern = re.compile(
+        rf"AbacusSummit_small_c{cosmo:03d}_ph(?P<phase>\d+)\/.+\/z{z_str}"
+    )
+
     phases = []
     for f in abacus_fns:
         match = re_pattern.search(str(f))
         if match:
             phases.append(int(match.group("phase")))
         else:
-            logger.warning(f"File {f} does not match the expected pattern and will be skipped.")
-    
+            logger.warning(
+                f"File {f} does not match the expected pattern and will be skipped."
+            )
+
     fns = [Path(phase_dir) / fn for fn in abacus_fns]
     return fns, phases

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [ # Base requirements
     "xarray", 
     "pyyaml",
     "matplotlib",
-    "sunbird[inference] @ git+https://github.com/florpi/sunbird'"
+    "sunbird[inference] @ git+https://github.com/florpi/sunbird",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ cosmodesi = [ # Dependencies existing in the cosmodesi ecosystem
     'cosmoprimo[class,camb,astropy,extras] @ git+https://github.com/cosmodesi/cosmoprimo',
     'fitsio',
     'h5py',
-    "lsstypes @ git+https://github.com/adematti/lsstypes.git ",
+    "lsstypes @ git+https://github.com/adematti/lsstypes.git",
     'healpy',
     'mockfactory @ git+https://github.com/cosmodesi/mockfactory',
     'desitarget',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,77 +25,53 @@ dependencies = [ # Base requirements
     "xarray", 
     "pyyaml",
     "matplotlib",
-    "getdist",
+    "sunbird[inference] @ git+https://github.com/florpi/sunbird'"
 ]
 dynamic = ["version"]
 
 [project.optional-dependencies]
-# Environements
-cosmodesi = [
-    # Estimators
+cosmodesi = [ # Dependencies existing in the cosmodesi ecosystem
     'jax',
-    'pycorr[mpi,jackknife,corrfunc] @ git+https://github.com/cosmodesi/pycorr',
-
-    # HOD and cutsky
     'astropy',
-    'abacusutils',  # abacusnbody
     'cosmoprimo[class,camb,astropy,extras] @ git+https://github.com/cosmodesi/cosmoprimo',
-    'mockfactory @ git+https://github.com/cosmodesi/mockfactory',
     'fitsio',
+    'h5py',
+    "lsstypes @ git+https://github.com/adematti/lsstypes.git ",
     'healpy',
+    'mockfactory @ git+https://github.com/cosmodesi/mockfactory',
     'desitarget',
     'regressis @ git+https://github.com/echaussidon/regressis',
 ]
-# Estimators (backends)
-jaxpower = [
-    'jax-power @ git+https://github.com/adematti/jax-power.git',
+estimators = [ # Dependencies for clustering estimators
+    "pycorr[mpi,jackknife,corrfunc] @ git+https://github.com/cosmodesi/pycorr",
+    "jax-power @ git+https://github.com/adematti/jax-power.git",
+    "numba", # knn
+    "mistreeplus @ git+https://github.com/knaidoo29/mistreeplus.git", # mst
+    "kymatio", # wst
 ]
-pypower = [
-    'pypower @ git+https://github.com/cosmodesi/pypower', 
+dark-matter = [ # Dependencies for dark matter backends
+    'abacusutils',  # abacusnbody
 ]
-pyrecon = [
-    'pyrecon @ git+https://github.com/cosmodesi/pyrecon@main',
+lensing = [
+    'asdf',
+    'treecorr',
 ]
-polybin3d = [
-    'polybin3d[mkl_fft] @ git+https://github.com/oliverphilcox/PolyBin3D',
-]
-# Documentation and testing
 docs = [
     "sphinx >= 4.2",
     "sphinx-book-theme >= 0.3",
     "myst_nb >= 0.17.1",
 ]
-testing = [
-    "pytest",
-    "coverage",
-    "pytest-docstyle",
-    "pytest-emoji",
-    "pylint",
-    "ruff",
-    "black",
-    "isort",
-    "mypy",
-    "ciqar",
+testing = [ # Testing dependencies, with minimal install for type hints
+    "ruff", 
     "ty",
-    "pytest-cov"
-]
-# Estimators
-knn = [
-    "numba",
-]
-mst = [
-    "mistreeplus @ git+https://github.com/knaidoo29/mistreeplus.git",
-]
-wst = [
-    "kymatio",
-]
-# Model & inference
-sunbird = [ 
-    'sunbird[inference] @ git+https://github.com/florpi/sunbird',
-]
-lensing = [
-    'asdf',
-    'treecorr',
+    "pytest",
+    "pytest-cov",
+    "pytest-emoji",
+    "requests",
+    "sunbird[inference] @ git+https://github.com/florpi/sunbird",
+    # not tested, but dependency of some imports - minimal install
+    "lsstypes @ git+https://github.com/adematti/lsstypes.git ",
+    "pycorr @ git+https://github.com/cosmodesi/pycorr", 
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ testing = [ # Testing dependencies, with minimal install for type hints
     "requests",
     "sunbird[inference] @ git+https://github.com/florpi/sunbird",
     # not tested, but dependency of some imports - minimal install
-    "lsstypes @ git+https://github.com/adematti/lsstypes.git ",
+    "lsstypes @ git+https://github.com/adematti/lsstypes.git",
     "pycorr @ git+https://github.com/cosmodesi/pycorr", 
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,30 +31,30 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 cosmodesi = [ # Dependencies existing in the cosmodesi ecosystem
-    'jax',
-    'astropy',
-    'cosmoprimo[class,camb,astropy,extras] @ git+https://github.com/cosmodesi/cosmoprimo',
-    'fitsio',
-    'h5py',
-    "lsstypes @ git+https://github.com/adematti/lsstypes.git",
-    'healpy',
-    'mockfactory @ git+https://github.com/cosmodesi/mockfactory',
-    'desitarget',
-    'regressis @ git+https://github.com/echaussidon/regressis',
+    "jax",
+    "astropy",
+    "cosmoprimo[class,camb,astropy,extras] @ git+https://github.com/cosmodesi/cosmoprimo",
+    "fitsio",
+    "h5py",
+    "healpy",
+    "desitarget",
+    "lsstypes @ git+https://github.com/adematti/lsstypes",
+    "mockfactory @ git+https://github.com/cosmodesi/mockfactory",
+    "regressis @ git+https://github.com/echaussidon/regressis",
 ]
 estimators = [ # Dependencies for clustering estimators
     "pycorr[mpi,jackknife,corrfunc] @ git+https://github.com/cosmodesi/pycorr",
-    "jax-power @ git+https://github.com/adematti/jax-power.git",
+    "jax-power @ git+https://github.com/adematti/jax-power",
+    "mistreeplus @ git+https://github.com/knaidoo29/mistreeplus", # mst
     "numba", # knn
-    "mistreeplus @ git+https://github.com/knaidoo29/mistreeplus.git", # mst
     "kymatio", # wst
 ]
 dark-matter = [ # Dependencies for dark matter backends
-    'abacusutils',  # abacusnbody
+    "abacusutils",  # abacusnbody
 ]
 lensing = [
-    'asdf',
-    'treecorr',
+    "asdf",
+    "treecorr",
 ]
 docs = [
     "sphinx >= 4.2",
@@ -70,7 +70,7 @@ testing = [ # Testing dependencies, with minimal install for type hints
     "requests",
     "sunbird[inference] @ git+https://github.com/florpi/sunbird",
     # not tested, but dependency of some imports - minimal install
-    "lsstypes @ git+https://github.com/adematti/lsstypes.git",
+    "lsstypes @ git+https://github.com/adematti/lsstypes",
     "pycorr @ git+https://github.com/cosmodesi/pycorr", 
 ]
 


### PR DESCRIPTION
This PR is a hotfix for the new type errors raised by the new ty update to allow tests to pass again.

I also fixed some extra type issues (including one raised in #252, where some functions used the `pycorr.TwoPointCorrelationFunction` function as a type hint - which caused issues. I fixed that by replacing those hints by `BaseTwoPointEstimator` hints instead.

I noticed that on a full install ty still raises some errors for galaxy estimators - to be fixed with #243