### PR TITLE
[Refactor] Semantic changes in acm.catalogs (#264)

### DIFF
--- a/acm/catalogs/backends/__init__.py
+++ b/acm/catalogs/backends/__init__.py
@@ -8,14 +8,15 @@ A backend is responsible for two things:
 To implement a new backend, subclass SnapshotBackend or LightconeBackend
 and register it with @register_backend("<name>").
 """
+
 from acm.utils.modules import check_installed
 
 from .base import (
-  DarkMatterBackend,
-  SnapshotBackend,
-  load_backend,
+    DarkMatterBackend,
+    SnapshotBackend,
+    load_backend,
 )
 
 # Register backends if possible:
-if check_installed('abacusnbody'):
-  from .abacus import AbacusHODBackend
+if check_installed("abacusnbody"):
+    from .abacus import AbacusHODBackend

--- a/acm/catalogs/backends/__init__.py
+++ b/acm/catalogs/backends/__init__.py
@@ -8,9 +8,14 @@ A backend is responsible for two things:
 To implement a new backend, subclass SnapshotBackend or LightconeBackend
 and register it with @register_backend("<name>").
 """
+from acm.utils.modules import check_installed
 
 from .base import (
-    DarkMatterBackend,
-    SnapshotBackend,
-    load_backend,
+  DarkMatterBackend,
+  SnapshotBackend,
+  load_backend,
 )
+
+# Register backends if possible:
+if check_installed('abacusnbody'):
+  from .abacus import AbacusHODBackend

--- a/acm/catalogs/backends/abacus.py
+++ b/acm/catalogs/backends/abacus.py
@@ -92,7 +92,7 @@ class AbacusHODBackend(SnapshotBackend):
         self.sim_type = sim_type
         self.sim_params = sim_params
         self.hod_params = hod_params
-        
+
         self._cache: dict[float, AbacusHOD]
 
     @override
@@ -104,10 +104,10 @@ class AbacusHODBackend(SnapshotBackend):
     ) -> AbacusHOD:
         if redshift in self._cache and no_cache is False:
             logger.debug(
-                f'Loaded dark matter catalog for redshift z={redshift:.3f} from cache.'
+                f"Loaded dark matter catalog for redshift z={redshift:.3f} from cache."
             )
             return self._cache[redshift]
-        
+
         sim_params = self.sim_params.copy()
         sim_params["z_mock"] = redshift
 

--- a/acm/catalogs/backends/abacus.py
+++ b/acm/catalogs/backends/abacus.py
@@ -56,6 +56,7 @@ class AbacusHODBackend(SnapshotBackend):
         ValueError
             If the config file is not found.
         """
+        super().__init__()
         if sim_type not in BOXSIZES:
             raise ValueError(
                 f"Unknown simulation type '{sim_type}'. Available types: {list(BOXSIZES)}"
@@ -91,13 +92,22 @@ class AbacusHODBackend(SnapshotBackend):
         self.sim_type = sim_type
         self.sim_params = sim_params
         self.hod_params = hod_params
+        
+        self._cache: dict[float, AbacusHOD]
 
     @override
     def load_dark_matter_catalog(
         self,
         redshift: float,
+        no_cache: bool = False,
         **kwargs,
     ) -> AbacusHOD:
+        if redshift in self._cache and no_cache is False:
+            logger.debug(
+                f'Loaded dark matter catalog for redshift z={redshift:.3f} from cache.'
+            )
+            return self._cache[redshift]
+        
         sim_params = self.sim_params.copy()
         sim_params["z_mock"] = redshift
 
@@ -109,7 +119,7 @@ class AbacusHODBackend(SnapshotBackend):
         logger.debug(
             f"Loaded dark matter catalog for redshift z={redshift:.3f} in {time.time() - t0:.2f} seconds."
         )
-
+        self._cache[redshift] = dark_matter_catalog
         return dark_matter_catalog
 
     @override

--- a/acm/catalogs/backends/abacus.py
+++ b/acm/catalogs/backends/abacus.py
@@ -265,7 +265,8 @@ class AbacusHODBackend(SnapshotBackend):
         tracer_flags = hod_params.get("tracer_flags", {})
 
         for tracer in tracers:
-            tracer_key = f"{tracer.name}_params"
+            tracer_name = self._resolve_tracer_name(tracer.name)
+            tracer_key = f"{tracer_name}_params"
 
             # Get the tracer parameters from the tracer instance with mapping
             ntp = map_params(tracer.params.copy(), mapping=mapping)
@@ -277,15 +278,15 @@ class AbacusHODBackend(SnapshotBackend):
 
             if len(tracer_params) == 0:
                 raise ValueError(
-                    f"Default HOD parameters for tracer '{tracer.name}' must be provided either through the config file, as kwargs, or in the tracer instance."
+                    f"Default HOD parameters for tracer '{tracer_name}' must be provided either through the config file, as kwargs, or in the tracer instance."
                 )
 
             logger.debug(
-                f"Setting default HOD parameters for tracer '{tracer.name}': {tracer_params}"
+                f"Setting default HOD parameters for tracer '{tracer_name}': {tracer_params}"
             )
 
             # Ensure flag is True, even if it wasn't set in the config file
-            tracer_flags[tracer.name] = True
+            tracer_flags[tracer_name] = True
 
         # Update tracer_flags in hod_params
         hod_params["tracer_flags"] = tracer_flags

--- a/acm/catalogs/backends/abacus.py
+++ b/acm/catalogs/backends/abacus.py
@@ -93,7 +93,7 @@ class AbacusHODBackend(SnapshotBackend):
         self.hod_params = hod_params
 
     @override
-    def get_dark_matter_catalog(
+    def load_dark_matter_catalog(
         self,
         redshift: float,
         **kwargs,

--- a/acm/catalogs/backends/base.py
+++ b/acm/catalogs/backends/base.py
@@ -59,7 +59,7 @@ class SnapshotBackend(DarkMatterBackend):
     Snapshot backends load one dark matter catalog per redshift, which maps
     naturally to N-body simulation suites.
     """
-    def __init__(self):
+    def __init__(self) -> None:
         self._cache: dict[float, object] = {} # Cache for dark matter catalogs
 
     @abstractmethod

--- a/acm/catalogs/backends/base.py
+++ b/acm/catalogs/backends/base.py
@@ -47,7 +47,7 @@ class DarkMatterBackend(ABC):
         ...
 
     @abstractmethod
-    def get_dark_matter_catalog(self, *args, **kwargs) -> object:
+    def load_dark_matter_catalog(self, *args, **kwargs) -> object:
         """Load the dark matter catalog, to be implemented by geometry-specific subclasses."""
         ...
 
@@ -61,7 +61,7 @@ class SnapshotBackend(DarkMatterBackend):
     """
 
     @abstractmethod
-    def get_dark_matter_catalog(self, redshift: float, **kwargs) -> object:
+    def load_dark_matter_catalog(self, redshift: float, **kwargs) -> object:
         """
         Load the dark matter catalog for the specified redshift and tracers.
 

--- a/acm/catalogs/backends/base.py
+++ b/acm/catalogs/backends/base.py
@@ -59,8 +59,9 @@ class SnapshotBackend(DarkMatterBackend):
     Snapshot backends load one dark matter catalog per redshift, which maps
     naturally to N-body simulation suites.
     """
+
     def __init__(self) -> None:
-        self._cache: dict[float, object] = {} # Cache for dark matter catalogs
+        self._cache: dict[float, object] = {}  # Cache for dark matter catalogs
 
     @abstractmethod
     def load_dark_matter_catalog(

--- a/acm/catalogs/backends/base.py
+++ b/acm/catalogs/backends/base.py
@@ -59,9 +59,16 @@ class SnapshotBackend(DarkMatterBackend):
     Snapshot backends load one dark matter catalog per redshift, which maps
     naturally to N-body simulation suites.
     """
+    def __init__(self):
+        self._cache: dict[float, object] = {} # Cache for dark matter catalogs
 
     @abstractmethod
-    def load_dark_matter_catalog(self, redshift: float, **kwargs) -> object:
+    def load_dark_matter_catalog(
+        self,
+        redshift: float,
+        no_cache: bool = False,
+        **kwargs,
+    ) -> object:
         """
         Load the dark matter catalog for the specified redshift and tracers.
 

--- a/acm/catalogs/factories/snapshot.py
+++ b/acm/catalogs/factories/snapshot.py
@@ -142,7 +142,7 @@ class SnapshotCatalogFactory(BaseSnapshotFactory):
 
             logger.info(f"Loading dark matter catalog at redshift z={z:.3f}")
             dm_kwargs = dark_matter_kwargs or {}
-            dm_catalog = self.backend.get_dark_matter_catalog(redshift=z, **dm_kwargs)
+            dm_catalog = self.backend.load_dark_matter_catalog(redshift=z, **dm_kwargs)
 
             logger.info(
                 f"Populating galaxy catalog at redshift z={z:.3f} for tracers {[t.name for t in snapshot_tracers]}"

--- a/acm/catalogs/products/snapshot.py
+++ b/acm/catalogs/products/snapshot.py
@@ -247,7 +247,7 @@ class SnapshotCatalog(BaseGalaxyCatalog):
         """Number density of galaxies in the entire catalog."""
         return self._nbar()
 
-    def positions(self, raw: bool = True) -> pd.DataFrame:
+    def positions(self, raw: bool = False) -> pd.DataFrame:
         """
         Get the positions of galaxies in the full catalog.
 
@@ -256,6 +256,7 @@ class SnapshotCatalog(BaseGalaxyCatalog):
         raw : bool, optional
             If True, return the raw positions before any transformations.
             If False, return the positions after applying all transformations.
+            Defaults to False.
 
         Returns
         -------

--- a/acm/hod/box.py
+++ b/acm/hod/box.py
@@ -15,7 +15,7 @@ from acm.utils.paths import lookup_registry_path
 
 logger = logging.getLogger(__name__)
 
-
+logger.warning('DEPRECATED: `acm.hod` will be deprecated in v1.1.0. Use `acm.catalogs` instead')
 class BoxHOD:
     """
     BoxHOD is a wrapper around AbacusHOD, a class for handling Halo Occupation Distribution (HOD) modeling

--- a/acm/utils/modules.py
+++ b/acm/utils/modules.py
@@ -7,6 +7,7 @@ def get_class_from_module(module_path: str, class_name: str) -> type:
     cls = getattr(module, class_name)
     return cls
 
+
 def check_installed(name: str) -> bool:
     """Check if a package is installed on-fly."""
     try:

--- a/acm/utils/modules.py
+++ b/acm/utils/modules.py
@@ -6,3 +6,12 @@ def get_class_from_module(module_path: str, class_name: str) -> type:
     module = importlib.import_module(module_path)
     cls = getattr(module, class_name)
     return cls
+
+def check_installed(name: str) -> bool:
+    """Check if a package is installed on-fly."""
+    try:
+        importlib.import_module(name)
+    except ImportError:
+        return False
+    else:
+        return True

--- a/nb/catalogs_example.ipynb
+++ b/nb/catalogs_example.ipynb
@@ -43,7 +43,7 @@
     "\n",
     "class DummyBackend(SnapshotBackend):\n",
     "    \"\"\"A minimal implementation of DarkMatterBackend for testing.\"\"\"\n",
-    "    def get_dark_matter_catalog(self, redshift: float, **kwargs):\n",
+    "    def load_dark_matter_catalog(self, redshift: float, **kwargs):\n",
     "        return None  # Return a dummy catalog object\n",
     "\n",
     "    def make_galaxy_catalog(self, dm_catalog, tracers: list[Tracer], **kwargs) -> dict:\n",

--- a/tests/acm/catalogs/backends/test_backend_abacus.py
+++ b/tests/acm/catalogs/backends/test_backend_abacus.py
@@ -102,7 +102,7 @@ def tracer_bar():
 @pytest.fixture
 def dm_catalog(backend, tracer_foo):
     """A loaded dark matter catalog for a single tracer."""
-    return backend.get_dark_matter_catalog(redshift=0.5, tracers=[tracer_foo])
+    return backend.load_dark_matter_catalog(redshift=0.5, tracers=[tracer_foo])
 
 
 class TestInit:
@@ -131,27 +131,27 @@ class TestInit:
         assert b.sim_params["custom_param"] == 42
 
 
-class TestGetDarkMatterCatalog:
-    """Tests for AbacusHODBackend.get_dark_matter_catalog."""
+class TestLoadDarkMatterCatalog:
+    """Tests for AbacusHODBackend.load_dark_matter_catalog."""
 
     def test_returns_mock_abacus_hod(self, backend, tracer_foo):
-        dm = backend.get_dark_matter_catalog(redshift=0.5, tracers=[tracer_foo])
+        dm = backend.load_dark_matter_catalog(redshift=0.5, tracers=[tracer_foo])
         assert isinstance(dm, MockAbacusHOD)
 
     def test_redshift_set_in_sim_params(self, backend, tracer_foo):
-        """The redshift passed to get_dark_matter_catalog should be set in the sim_params of the returned AbacusHOD instance."""
-        dm = backend.get_dark_matter_catalog(redshift=0.8, tracers=[tracer_foo])
+        """The redshift passed should be set in the sim_params of the returned AbacusHOD instance."""
+        dm = backend.load_dark_matter_catalog(redshift=0.8, tracers=[tracer_foo])
         assert dm.sim_params["z_mock"] == 0.8
 
     def test_tracer_flag_enabled(self, backend, tracer_foo):
         """Requesting a tracer should set its flag to True in the returned AbacusHOD instance."""
-        dm = backend.get_dark_matter_catalog(redshift=0.5, tracers=[tracer_foo])
+        dm = backend.load_dark_matter_catalog(redshift=0.5, tracers=[tracer_foo])
         assert dm.hod_params["tracer_flags"]["FOO"] is True
 
     def test_tracer_params_overridden(self, backend):
         """Params passed in the tracer should override those in the config."""
         tracer = Tracer(name="FOO", params={"alpha": 99.0})
-        dm = backend.get_dark_matter_catalog(redshift=0.5, tracers=[tracer])
+        dm = backend.load_dark_matter_catalog(redshift=0.5, tracers=[tracer])
         assert dm.hod_params["FOO_params"]["alpha"] == 99.0
 
     def test_missing_tracer_params_raises(self, config_file, tmp_path):
@@ -167,7 +167,7 @@ class TestGetDarkMatterCatalog:
         path.write_text(yaml.dump(config))
         b = AbacusHODBackend(config_file=path)
         with pytest.raises(ValueError, match="HOD parameters"):
-            b.get_dark_matter_catalog(redshift=0.5, tracers=[Tracer(name="FOO")])
+            b.load_dark_matter_catalog(redshift=0.5, tracers=[Tracer(name="FOO")])
 
 
 class TestMakeGalaxyCatalog:
@@ -202,7 +202,7 @@ class TestMakeGalaxyCatalog:
     def test_bgs_alone_accepted(self, backend):
         """BGS requested alone should not raise."""
         tracer = Tracer(name="LRG", params={"alpha": 1.0})
-        dm_catalog = backend.get_dark_matter_catalog(redshift=0.5, tracers=[tracer])
+        dm_catalog = backend.load_dark_matter_catalog(redshift=0.5, tracers=[tracer])
         tracer = Tracer(name="BGS", params={})
         result = backend.make_galaxy_catalog(dm_catalog, tracers=[tracer])
         assert tracer in result

--- a/tests/acm/catalogs/backends/test_backend_abacus.py
+++ b/tests/acm/catalogs/backends/test_backend_abacus.py
@@ -168,7 +168,30 @@ class TestLoadDarkMatterCatalog:
         b = AbacusHODBackend(config_file=path)
         with pytest.raises(ValueError, match="HOD parameters"):
             b.load_dark_matter_catalog(redshift=0.5, tracers=[Tracer(name="FOO")])
+            
+    def test_cache_populated_after_first_load(self, backend, tracer_foo):
+        """Cache should contain the redshift key after first load."""
+        backend.load_dark_matter_catalog(redshift=0.5, tracers=[tracer_foo])
+        assert 0.5 in backend._cache
+        
+    def test_cache_returns_same_instance(self, backend, tracer_foo):
+        """Second call with same redshift should return the exact same object."""
+        dm1 = backend.load_dark_matter_catalog(redshift=0.5, tracers=[tracer_foo])
+        dm2 = backend.load_dark_matter_catalog(redshift=0.5, tracers=[tracer_foo])
+        assert dm1 is dm2
 
+    def test_no_cache_bypasses_cache(self, backend, tracer_foo):
+        """no_cache=True should return a new instance even if redshift is cached."""
+        dm1 = backend.load_dark_matter_catalog(redshift=0.5, tracers=[tracer_foo])
+        dm2 = backend.load_dark_matter_catalog(redshift=0.5, tracers=[tracer_foo], no_cache=True)
+        assert dm1 is not dm2
+        
+    def test_different_redshifts_cached_separately(self, backend, tracer_foo):
+        """Each redshift should get its own cache entry."""
+        backend.load_dark_matter_catalog(redshift=0.5, tracers=[tracer_foo])
+        backend.load_dark_matter_catalog(redshift=1.0, tracers=[tracer_foo])
+        assert 0.5 in backend._cache
+        assert 1.0 in backend._cache
 
 class TestMakeGalaxyCatalog:
     """Tests for AbacusHODBackend.make_galaxy_catalog."""

--- a/tests/acm/catalogs/factories/test_factory_snapshot.py
+++ b/tests/acm/catalogs/factories/test_factory_snapshot.py
@@ -68,7 +68,7 @@ def mock_backend():
 def magic_mock_factory():
     """A factory using MagicMock to mimics SnapshotBackend with valid return values."""
     backend = MagicMock(spec=DarkMatterBackend)
-    backend.get_dark_matter_catalog.return_value = MagicMock()
+    backend.load_dark_matter_catalog.return_value = MagicMock()
     backend.make_galaxy_catalog.side_effect = lambda dm_catalog, tracers, **kwargs: {t: make_tracer_data() for t in tracers}
     backend.boxsize = 500.0
     
@@ -172,8 +172,8 @@ class TestMakeCatalogs:
             tracers=[tracer_foo],
             dark_matter_kwargs=dark_matter_kwargs,
         )
-        magic_mock_factory.backend.get_dark_matter_catalog.assert_called_once()
-        call_kwargs = magic_mock_factory.backend.get_dark_matter_catalog.call_args[1]
+        magic_mock_factory.backend.load_dark_matter_catalog.assert_called_once()
+        call_kwargs = magic_mock_factory.backend.load_dark_matter_catalog.call_args[1]
         assert call_kwargs["redshift"] == 0.5
         assert call_kwargs["seed"] == 42
         assert call_kwargs["cosmology_variant"] == "base"

--- a/tests/acm/catalogs/factories/test_factory_snapshot.py
+++ b/tests/acm/catalogs/factories/test_factory_snapshot.py
@@ -27,7 +27,7 @@ def make_tracer_data(n: int = 100) -> pd.DataFrame:
     
 class DummyBackend(DarkMatterBackend):
     """A minimal implementation of DarkMatterBackend for testing."""
-    def get_dark_matter_catalog(self, redshift: float, **kwargs):
+    def load_dark_matter_catalog(self, redshift: float, **kwargs):
         return MagicMock()  # Return a dummy catalog object
 
     def make_galaxy_catalog(self, dm_catalog, tracers: list[Tracer], **kwargs) -> None:

--- a/tests/acm/utils/test_modules.py
+++ b/tests/acm/utils/test_modules.py
@@ -1,25 +1,27 @@
-import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
-from acm.utils.modules import get_class_from_module
+import pytest
+
+from acm.utils.modules import check_installed, get_class_from_module
+
 
 class TestGetClassFromModule:
-    
+
     def test_returns_builtin_class(self):
         """Test that the function can retrieve a built-in class."""
         cls = get_class_from_module("builtins", "int")
         assert cls is int
-        
+
     def test_raises_on_missing_module(self):
         """Test that the function raises an error when the module cannot be found."""
         with pytest.raises(ModuleNotFoundError):
             get_class_from_module("totally.fake.module", "SomeClass")
-            
+
     def test_raises_on_missing_attribute(self):
         """Test that the function raises an error when the class cannot be found in the module."""
         with pytest.raises(AttributeError):
             get_class_from_module("builtins", "NonExistentClass")
-            
+
     def test_returns_class_from_mocked_module(self):
         """Class returned is exactly the one attached to the mock module."""
         mock_module = MagicMock()
@@ -30,7 +32,7 @@ class TestGetClassFromModule:
             result = get_class_from_module("fake.module", "MyClass")
 
         assert result is mock_class
-        
+
     def test_import_module_called_with_correct_path(self):
         """importlib.import_module is called with the exact module path provided."""
         mock_module = MagicMock()
@@ -39,3 +41,10 @@ class TestGetClassFromModule:
             get_class_from_module("some.module.path", "AnyAttr")
 
         mock_import.assert_called_once_with("some.module.path")
+
+class TestCheckInstalled:
+    def test_installed_package(self):
+        assert check_installed("numpy") is True
+
+    def test_missing_package(self):
+        assert check_installed("definitely_not_a_real_package") is False


### PR DESCRIPTION
Fix some small semantic issues in `acm.catalogs`:
- Changed `get_dark_matter_catalog` to `load_dark_matter_catalog` (as it's read from disk) (#264)
- Added loading cache to the DM backends to not reload the dark matter catalog when calling make_catalog (which calls `load_dark_matter_catalog` at each run to get the different catalogs redshifts)
- Fixed a tracer name resolution issue in AbacusHODBackend that caused a crash
- Added deprecation warning in `acm.hod` (#270)
- Replaced default value raw=False in `SnapshotCatalog.positions` (#264)
- Added default import of available DM backends to make registration effective