### PR TITLE
[Hotfix] Make deepcopy of default dicts when updating the tracers

### DIFF
--- a/acm/catalogs/backends/abacus.py
+++ b/acm/catalogs/backends/abacus.py
@@ -1,5 +1,6 @@
 import logging
 import time
+from copy import deepcopy
 from pathlib import Path
 from typing import override
 
@@ -111,10 +112,10 @@ class AbacusHODBackend(SnapshotBackend):
             Parameters to override the default HOD parameters for each tracer.
             See :meth:`update_default_tracers` for details on how to provide tracer-specific HOD parameters.
         """
-        sim_params = self.sim_params.copy()
+        sim_params = deepcopy(self.sim_params)
         sim_params["z_mock"] = redshift
 
-        hod_params = self.hod_params
+        hod_params = deepcopy(self.hod_params)
         self.update_default_tracers(hod_params, **kwargs)
 
         t0 = time.time()
@@ -262,8 +263,9 @@ class AbacusHODBackend(SnapshotBackend):
 
         return galaxy_catalogs
 
+    @classmethod
     def update_default_tracers(
-        self,
+        cls,
         hod_params: dict,
         tracers: list[Tracer] | None = None,
         mapping: dict[str, list[str]] | None = None,
@@ -289,12 +291,18 @@ class AbacusHODBackend(SnapshotBackend):
         ------
         ValueError
             If default HOD parameters for any tracer are missing after the update.
+
+        Note
+        ----
+        This method updates the input `hod_params` dictionary in-place and does not return a new dictionary.
+        It does not disable already existing tracers in `hod_params`; but ensures that any requested tracers are set to active (i.e. their flags are True).
+        To have a tracer optional, disable it at the initialization of the AbacusHODBackend, and only request it when needed.
         """
         tracers = tracers or []
         tracer_flags = hod_params.get("tracer_flags", {})
 
         for tracer in tracers:
-            tracer_name = self._resolve_tracer_name(tracer.name)
+            tracer_name = cls._resolve_tracer_name(tracer.name)
             tracer_key = f"{tracer_name}_params"
 
             # Get the tracer parameters from the tracer instance with mapping
@@ -361,7 +369,8 @@ class AbacusHODBackend(SnapshotBackend):
         is_central[:n_cent] = 1
         galaxy_dict[tracer_name]["is_cent"] = is_central
 
-    def _resolve_tracer_name(self, name: str) -> str:
+    @staticmethod
+    def _resolve_tracer_name(name: str) -> str:
         """
         Resolve a tracer name to the name expected by AbacusHOD, using the _TRACER_NAME_ALIASES mapping.
 

--- a/acm/utils/abacus.py
+++ b/acm/utils/abacus.py
@@ -51,9 +51,11 @@ def map_params(
     ----------
     params : dict | list[str]
         Dictionary or list of custom parameters.
-    mapping : dict[str, list[str]]
+    mapping : dict[str, list[str]], optional
         Mapping from custom parameter names to fixed parameter names.
         Keys are fixed parameter names, values are lists of custom parameter names that map to the fixed parameter name.
+        If set to None, the default mapping (ABACUS_MAP) will be used.
+        Default is None.
 
     Returns
     -------

--- a/tests/acm/catalogs/backends/test_backend_abacus.py
+++ b/tests/acm/catalogs/backends/test_backend_abacus.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 import pandas as pd
 import pytest
 import yaml
@@ -101,11 +103,23 @@ class TestLoadDarkMatterCatalog:
         dm = backend._cache[0.8]  # Access the cached instance
         assert dm.sim_params["z_mock"] == 0.8
 
-    def test_tracer_flag_enabled(self, backend, tracer_foo):
-        """Requesting a tracer should set its flag to True in the returned AbacusHOD instance."""
+    def test_backend_params_unchanged(self, backend, tracer_foo):
+        """The backend's hod_params and sim_params should remain unchanged after loading a catalog."""
+        # Deepcopy because init changes config values for the sim_params (e.g. sim_name)
+        original_hod_params = deepcopy(backend.hod_params)
+        original_sim_params = deepcopy(backend.sim_params)
         backend.load_dark_matter_catalog(redshift=0.5, tracers=[tracer_foo])
+        assert backend.hod_params == original_hod_params
+        assert backend.sim_params == original_sim_params
+
+    def test_tracer_flag_enabled(self, backend, tracer_bar):
+        """Requesting a tracer should set its flag to True in the returned AbacusHOD instance."""
+        backend.load_dark_matter_catalog(redshift=0.5, tracers=[tracer_bar])
         dm = backend._cache[0.5]  # Access the cached instance
+        assert "FOO" in dm.tracers # Not requested, but True in config
         assert dm.hod_params["tracer_flags"]["FOO"] is True
+        assert "BAR" in dm.tracers
+        assert dm.hod_params["tracer_flags"]["BAR"] is True
 
     def test_tracer_params_overridden(self, backend):
         """Params passed in the tracer should override those in the config."""
@@ -113,6 +127,16 @@ class TestLoadDarkMatterCatalog:
         backend.load_dark_matter_catalog(redshift=0.5, tracers=[tracer])
         dm = backend._cache[0.5]  # Access the cached instance
         assert dm.hod_params["FOO_params"]["alpha"] == 99.0
+
+    def test_tracer_name_only(self, backend):
+        """Passing a Tracer with only a name and no params should use the config params."""
+        tracer = Tracer(name="BAR") # Implicitly no params
+        backend.load_dark_matter_catalog(redshift=0.5, tracers=[tracer])
+        dm = backend._cache[0.5]  # Access the cached instance
+        assert "FOO" in dm.tracers # Not requested, but True in config
+        assert dm.hod_params["FOO_params"]["alpha"] == 1.0 # Default from config
+        assert "BAR" in dm.tracers
+        assert dm.hod_params["BAR_params"]["alpha"] == 0.8 # Default from config
 
     def test_missing_tracer_params_raises(self, config_file, tmp_path):
         """A tracer with no params in config and no params in tracer should raise."""
@@ -320,6 +344,8 @@ class TestUpdateDefaultTracers:
         """Calling with no tracers should not raise if flags are already set."""
         hod_params = {"tracer_flags": {"FOO": True}, "FOO_params": {"alpha": 1.0}}
         backend.update_default_tracers(hod_params)  # no tracers kwarg
+        assert hod_params["tracer_flags"]["FOO"] is True
+        assert hod_params["FOO_params"]["alpha"] == 1.0 # remains unchanged
 
     def test_new_tracer_added_to_flags(self, backend):
         """A tracer not previously in tracer_flags should be added."""


### PR DESCRIPTION
This is a small fix that could cause eventual issues when setting the same tracer for several snapshots.
I also added extra tests and clarified some docstrings on the tracer flags behaviors