### PR TITLE
fix: add coverage ignore to scripts

### DIFF
--- a/acm/utils/scripts.py
+++ b/acm/utils/scripts.py
@@ -16,7 +16,7 @@ import yaml
 
 try:
     from jax import clear_caches  # pyright: ignore[reportMissingImports]
-except ImportError:
+except ImportError:  # pragma: no cover
     clear_caches = lambda: None  # noqa: E731
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Tests can't test the `ImportError` case  in the `acm.utils.scripts` file (as `jax` is available by default); I'm adding a `#pragma: no cover` comment to avoid a void in the coverage report

> No review needed if tests pass and missing coverage is solved